### PR TITLE
feat(dapp-sdk): add Slay Money to the wallet registry

### DIFF
--- a/sdk/dapp-sdk/src/wallets.json
+++ b/sdk/dapp-sdk/src/wallets.json
@@ -11,5 +11,18 @@
                 "url": "https://chromewebstore.google.com/detail/send-connect/ldmohiccoioolenadmogclhoklmanpgi"
             }
         ]
+    },
+    {
+        "name": "Slay Money",
+        "type": "browser",
+        "providerId": "money.slay",
+        "description": "Canton wallet in the browser side panel \u2014 send by @handle, swap, and approve dApp transactions",
+        "icon": "https://slay.money/icon.png",
+        "installUrls": [
+            {
+                "platform": "chrome",
+                "url": "https://chromewebstore.google.com/detail/slay-money/poekioidghjohdgkkjdhijjljgkahmng"
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Slay Money is a CIP-0103 browser wallet for Canton, published on the Chrome Web Store. It already announces itself via canton:announceProvider, so it is discoverable at runtime; this entry adds it to the installable list so users who do not have it yet can find it in the picker.

All ten dApp API methods and all three events are implemented and exercised against a live MainNet validator: connect, disconnect, isConnected, status, getActiveNetwork, listAccounts, getPrimaryAccount, signMessage, prepareExecute, ledgerApi, plus accountsChanged, statusChanged and txChanged.

One note on `providerId`. The existing entry uses `browser:ext:<extension-id>`, but announce-discovery.ts stores `detail.id` verbatim with no transformation, so the registry id has to match what the wallet actually announces — for us that is `money.slay`. Using the `browser:ext:` form would leave the picker unable to tell the announced provider and this entry apart, and likely show Slay twice. Happy to change it if the convention is meant to be the other way round.