### PR TITLE
docs(portfolio): add docker-compose example for portfolio + gateway

### DIFF
--- a/docs/wallet-gateway/deployment/index.md
+++ b/docs/wallet-gateway/deployment/index.md
@@ -40,6 +40,10 @@ docker run -p 3030:3030 \
 
 If all went well, the Wallet Gateway login page can be opened in a browser at http://localhost:3030.
 
+### Docker Compose (local development)
+
+For a local setup running the Wallet Gateway alongside the [Splice Portfolio](../../dapp-building/examples/portfolio/index.md) dApp and a LocalNet instance, see the [`docker-compose.yaml` example](https://github.com/canton-network/wallet/blob/main/examples/portfolio/docker-compose.yaml) in `examples/portfolio`.
+
 ## Helm
 
 An official Helm chart is available for Kubernetes deployments. The full values.schema is [here](https://github.com/digital-asset/wallet-gateway/blob/main/charts/wallet-gateway/values.schema.json), but the important thing to note is that the Wallet Gateway is configured through the top-level `config:` key in `values.yaml`.

--- a/examples/portfolio/README.md
+++ b/examples/portfolio/README.md
@@ -75,6 +75,31 @@ pnpm start:all     # starts all services via pm2
 pnpm stop:all      # stops all services
 ```
 
+## Running with Docker Compose
+
+[`docker-compose.yaml`](docker-compose.yaml) wires together the published Wallet Gateway and Splice Portfolio Docker images against a LocalNet instance, using the config files in [`docker/`](docker/).
+
+First, start LocalNet from the repository root (if it isn't already running):
+
+```bash
+pnpm script:fetch:localnet
+pnpm start:localnet
+```
+
+Then, from this directory:
+
+```bash
+cd examples/portfolio
+docker compose up
+```
+
+- Portfolio UI: [http://localhost:3333](http://localhost:3333)
+- Wallet Gateway: [http://localhost:3030](http://localhost:3030)
+
+Stop everything with `docker compose down` (and `pnpm stop:localnet` from the repository root).
+
+See [Deploying a wallet gateway](../../docs/wallet-gateway/deployment/index.md) for production Docker/Helm deployment guidance.
+
 ## Further Reading
 
 See the [dApp Building Guide](../../docs/dapp-building) for full documentation on the dApp SDK, Wallet Gateway configuration, APIs, and signing providers.

--- a/examples/portfolio/docker-compose.yaml
+++ b/examples/portfolio/docker-compose.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Runs a Wallet Gateway + the Splice Portfolio dApp against a LocalNet instance.
+#
+# Prerequisites: start LocalNet first (from the repository root):
+#   pnpm script:fetch:localnet
+#   pnpm start:localnet
+#
+# Then, from this directory:
+#   docker compose up
+#
+# Portfolio UI: http://localhost:3333
+# Wallet Gateway: http://localhost:3030
+#
+# See ../../docs/wallet-gateway/deployment/index.md for production deployment guidance.
+
+services:
+    wallet-gateway:
+        image: ghcr.io/digital-asset/wallet-gateway/docker/wallet-gateway:v1.9.0
+        ports:
+            - '3030:3030'
+        volumes:
+            - ./docker/wallet-gateway.config.json:/app/config.json:ro
+            - wallet-gateway-data:/data
+        extra_hosts:
+            # LocalNet's ledger API is published on the host by `pnpm start:localnet`.
+            # `host.docker.internal` resolves out of the box on Docker Desktop
+            # (Mac/Windows); this entry makes it resolve on Linux too.
+            - 'host.docker.internal:host-gateway'
+
+    portfolio:
+        image: ghcr.io/digital-asset/splice-portfolio/docker/splice-portfolio:v1.9.0
+        ports:
+            - '3333:80'
+        volumes:
+            - ./docker/portfolio.config.json:/usr/share/nginx/html/config.json:ro
+        depends_on:
+            - wallet-gateway
+
+volumes:
+    wallet-gateway-data:

--- a/examples/portfolio/docker/portfolio.config.json
+++ b/examples/portfolio/docker/portfolio.config.json
@@ -1,0 +1,16 @@
+{
+    "amulet": {
+        "validatorUrl": "http://localhost:2000/api/validator",
+        "registry": "http://scan.localhost:4000/registry/"
+    },
+    "token": {
+        "validatorUrl": "http://localhost:2000/api/validator",
+        "registries": [
+            {
+                "name": "DA Registry",
+                "partyId": "operator::1234567890",
+                "url": "https://apps.da.com/registrar/operator::1234567890/"
+            }
+        ]
+    }
+}

--- a/examples/portfolio/docker/wallet-gateway.config.json
+++ b/examples/portfolio/docker/wallet-gateway.config.json
@@ -1,0 +1,56 @@
+{
+    "kernel": {
+        "id": "remote-da",
+        "clientType": "remote"
+    },
+    "server": {
+        "host": "localhost",
+        "port": 3030,
+        "tls": false,
+        "dappPath": "/api/v0/dapp",
+        "userPath": "/api/v0/user",
+        "allowedOrigins": ["http://localhost:3333", "http://localhost:8081"],
+        "admin": "operator"
+    },
+    "store": {
+        "connection": {
+            "type": "sqlite",
+            "database": "/data/store.sqlite"
+        }
+    },
+    "signingStore": {
+        "connection": {
+            "type": "sqlite",
+            "database": "/data/signingStore.sqlite"
+        }
+    },
+    "bootstrap": {
+        "networks": [
+            {
+                "id": "canton:localnet",
+                "name": "LocalNet",
+                "description": "LocalNet configuration",
+                "identityProviderId": "idp-self-signed",
+                "auth": {
+                    "method": "self_signed",
+                    "issuer": "self-signed",
+                    "audience": "https://canton.network.global",
+                    "scope": "openid daml_ledger_api offline_access",
+                    "clientId": "ledger-api-user",
+                    "clientSecret": "unsafe"
+                },
+                "adminAuth": {
+                    "method": "self_signed",
+                    "issuer": "self-signed",
+                    "scope": "openid daml_ledger_api offline_access",
+                    "audience": "https://canton.network.global",
+                    "clientId": "ledger-api-user",
+                    "clientSecret": "unsafe"
+                },
+                "ledgerApi": {
+                    "baseUrl": "http://host.docker.internal:2975"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `docker-compose.yaml` example wiring together LocalNet, the Wallet Gateway, and the Splice Portfolio dApp, as requested in #1941.

Both the Wallet Gateway and Splice Portfolio already ship official, public Docker images (documented in `docs/wallet-gateway/deployment` and `docs/dapp-building/examples/portfolio`), so this composes those two together on top of a LocalNet instance started with the existing `pnpm start:localnet` tooling, rather than duplicating that (versioned, auto-fetched) LocalNet compose stack.

- `examples/portfolio/docker-compose.yaml`: `wallet-gateway` (v1.9.0) + `portfolio` (v1.9.0) services. `wallet-gateway` reaches LocalNet's ledger API via `host.docker.internal` (with a Linux `extra_hosts` shim); `portfolio`'s `config.json` is browser-facing so it keeps `localhost` URLs.
- `examples/portfolio/docker/wallet-gateway.config.json`: self-signed LocalNet auth config, adapted from the existing checked-in example at `docs/dapp-building/examples/json/default-config.json`.
- `examples/portfolio/docker/portfolio.config.json`: matches the strict `portfolioConfigSchema` in `examples/portfolio/src/lib/schemas.ts`.
- Fixed the config mount path vs. the existing docs snippet in `docs/dapp-building/examples/portfolio/index.md` (which mounts a single file over nginx's whole html root) — this mounts to `/usr/share/nginx/html/config.json` specifically, matching where the portfolio app actually fetches its config (`/config.json`).
- Linked the new compose example from `docs/wallet-gateway/deployment/index.md` and `examples/portfolio/README.md`.

## Verification

- `docker compose config` validates the compose file cleanly.
- Both config JSON files were checked against their respective zod schemas by reading source directly: `wallet-gateway.config.json` against `Config.ts`'s `rawConfigSchema` and the `self_signed` auth fixtures in `core/wallet-auth/src/*.test.ts`; `portfolio.config.json` against `portfolioConfigSchema` in `examples/portfolio/src/lib/schemas.ts`.
- **Not yet live-tested end-to-end** against a running LocalNet — Docker daemon wasn't running and disk space was tight in the environment I built this in (LocalNet is a multi-GB multi-container download). Flagging this openly per the LocalNet ledger API port (`2975`) and self-signed auth shape being taken from the repo's own existing checked-in example config, which gives me reasonable confidence, but a live `docker compose up` run against a fresh LocalNet would still be good before merge.

## Test plan

- [ ] Run `pnpm script:fetch:localnet && pnpm start:localnet` then `docker compose up` from `examples/portfolio/` and confirm the Portfolio UI loads at `http://localhost:3333` and can talk to the Wallet Gateway at `http://localhost:3030`.

Fixes #1941