### PR TITLE
Add regression test for server.signingWorker being fully optional

### DIFF
--- a/wallet-gateway/remote/src/config/Config.test.ts
+++ b/wallet-gateway/remote/src/config/Config.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, test } from 'vitest'
+import { serverConfigSchema } from './Config.js'
 import { ConfigUtils } from './ConfigUtils.js'
 
 test('config from json file', async () => {
@@ -27,4 +28,9 @@ test('config from json file', async () => {
             'devnet_secret_testval'
         )
     }
+})
+
+test('server.signingWorker is fully optional and defaults when omitted', () => {
+    const parsed = serverConfigSchema.parse({})
+    expect(parsed.signingWorker.pollInterval).toBe(5000)
 })


### PR DESCRIPTION
## Summary

`server.signingWorker` (`wallet-gateway/remote/src/config/Config.ts`) is already wrapped in `z.preprocess((val) => val ?? {}, ...)`, with `pollInterval` defaulting to `5000`. That already makes the whole `signingWorker` block optional, with a sane default, exactly as #2176 asks for at the config-schema level -- it just had no direct test coverage, so a regression here would be easy to miss. This PR adds that coverage.

I could not find a helm chart in this repo (`grep -rn signingWorker -- *.yaml *.yml` turns up nothing), so the "propagate to the helm chart" part of the issue doesn't apply here -- it most likely refers to a different/deployment repo, or the chart has since moved/been removed. Flagging this in case a maintainer wants to redirect that part of the issue elsewhere or close it as already resolved.

Fixes #2176

## Test plan

- [x] Verified the exact zod mechanics in isolation (`z.preprocess(val => val ?? {}, z.object({ pollInterval: z.number().int().positive().default(5000) }))` parsed against `{}` in this repo's actual zod version) produce `{ pollInterval: 5000 }`, matching the new test's assertion
- [ ] Could not run the full `vitest` suite locally in a fresh worktree -- a sibling package (`core-token-standard`) requires Daml-generated codegen artifacts not available outside the full dev environment; unrelated to this change