### PR TITLE
chore: delete stale versioned clients when regenerating openapi/asyncapi codegen

### DIFF
--- a/scripts/src/generate-asyncapi-clients.ts
+++ b/scripts/src/generate-asyncapi-clients.ts
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import {
+    cleanupStaleVersionedFiles,
     getRepoRoot,
     info,
     error,
@@ -306,6 +307,18 @@ async function generateAsyncApiClient(
 async function main(network: Network = 'devnet', root: string = process.cwd()) {
     const cantonVersion =
         SUPPORTED_VERSIONS[network].canton.version.split('-')[0]
+
+    // Remove any versioned output that no longer matches a currently supported
+    // Canton version (across all networks, not just the one being generated for
+    // here) before writing new ones, so version bumps don't leave stale clients
+    // behind (#1380).
+    cleanupStaleVersionedFiles(
+        path.join(root, 'core/ledger-client-types/src/generated-clients'),
+        'asyncapi',
+        Object.values(SUPPORTED_VERSIONS).map(
+            (v) => v.canton.version.split('-')[0]
+        )
+    )
 
     await Promise.all(
         specs(cantonVersion).map((spec) => generateAsyncApiClient(spec, root))

--- a/scripts/src/generate-openapi-clients.ts
+++ b/scripts/src/generate-openapi-clients.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+    cleanupStaleVersionedFiles,
     downloadAndUnpackTarball,
     downloadToFile,
     ensureDir,
@@ -200,6 +201,19 @@ const getSpecs = (
 
 async function main(network: Network = 'devnet') {
     const updateHash = hasFlag('updateHash')
+
+    // The ledger-api spec is the only one whose output filename embeds the Canton
+    // version; the others overwrite a fixed filename in place. Remove any versioned
+    // output that no longer matches a currently supported Canton version (across all
+    // networks, not just the one being generated for here) before writing new ones,
+    // so version bumps don't leave stale clients behind (#1380).
+    cleanupStaleVersionedFiles(
+        path.join(root, 'core/ledger-client-types/src/generated-clients'),
+        'openapi',
+        Object.values(SUPPORTED_VERSIONS).map(
+            (v) => v.canton.version.split('-')[0]
+        )
+    )
 
     await fetchSpliceSpecs(updateHash, network)
     Promise.all(

--- a/scripts/src/lib/utils.ts
+++ b/scripts/src/lib/utils.ts
@@ -308,6 +308,28 @@ export function getAllFilesWithExtension(
     return results
 }
 
+// Delete generated files like `<prefix>-<version>.ts`, `<prefix>-<version>-paths.ts`,
+// `<prefix>-<version>-provider-types.ts`, or their `.d.ts`/`.d.ts.map` build artifacts,
+// for any <version> that isn't in currentVersions. Used to stop codegen scripts from
+// piling up stale versioned clients across Canton version bumps (see #1380).
+export function cleanupStaleVersionedFiles(
+    dir: string,
+    prefix: string,
+    currentVersions: string[]
+): void {
+    if (!fs.existsSync(dir)) return
+    const pattern = new RegExp(
+        `^${prefix}-(\\d+\\.\\d+\\.\\d+)(?:-paths|-provider-types)?\\.(?:d\\.ts\\.map|d\\.ts|ts)$`
+    )
+    for (const entry of fs.readdirSync(dir)) {
+        const match = entry.match(pattern)
+        if (match && !currentVersions.includes(match[1])) {
+            console.log(warn(`Removing stale generated file: ${entry}`))
+            fs.unlinkSync(path.join(dir, entry))
+        }
+    }
+}
+
 // Ensure a directory exists
 export async function ensureDir(dir: string) {
     if (!fs.existsSync(dir)) {


### PR DESCRIPTION
## Summary

`generate-openapi-clients.ts` and `generate-asyncapi-clients.ts` write Canton ledger-api output into `core/ledger-client-types/src/generated-clients` with the Canton version embedded in the filename (`openapi-<version>.ts`, `-paths.ts`, `-provider-types.ts`, `asyncapi-<version>.ts`). Every Canton version bump created a new versioned file without removing the old one. The repo currently has 6 Canton versions' worth of these files checked in (3.4.12, 3.5.1, 3.5.8, 3.5.10, 3.5.14) -- most no longer referenced by `version-config.json` at all.

Added `cleanupStaleVersionedFiles()` (`scripts/src/lib/utils.ts`), run at the start of both scripts, which deletes any `openapi-*`/`asyncapi-*` file whose embedded version isn't currently configured for *any* network (so running for one network doesn't delete the other network's valid file).

## Scope note

This fixes the scripts going forward. It deliberately does **not**:
- delete the already-stale checked-in files (3.4.12, 3.5.1, 3.5.8), or
- touch `core/ledger-client-types/src/index.ts`, which still hardcodes `openapi-3.4.12`/`openapi-3.5.1` as the `'3.4'`/`'3.5'` `LedgerApiVersion` union.

That `'3.4'`/`'3.5'` scheme turned out to be load-bearing business logic well beyond this package -- default client versions and version-parsing logic in `core/ledger-client` and `core/asyncapi-client`, plus hardcoded `cantonVersion: '3.4'` test fixtures in `wallet-gateway/remote`. Both currently supported Canton versions (3.5.10 mainnet, 3.5.14 devnet) are already in the same "3.5" family, so deciding which patch backs that key going forward -- or restructuring the versioning scheme entirely -- needs a maintainer's call, not something a codegen cleanup script should decide. Happy to take that on as a follow-up if a maintainer can weigh in on intent.

Fixes #1380

## Test plan

- [x] `tsc -b` clean in `scripts/`
- [x] `eslint` / `prettier --check` clean on all 3 changed files
- [x] Functionally tested `cleanupStaleVersionedFiles` against a fixture mirroring the repo's actual file set (all 6 checked-in Canton versions + an unrelated file): confirmed it removes exactly the 3.4.12/3.5.1/3.5.8 files (including `.d.ts`/`.d.ts.map`) and keeps 3.5.10/3.5.14 and the unrelated file
- [ ] Could not run the actual `script:generate:openapi`/`script:generate:asyncapi` end-to-end (needs network access to fetch specs from GitHub releases) -- the cleanup step itself is verified in isolation above