### PR TITLE
Allow supplying a custom stylesheet for the dApp SDK's wallet picker popup

### DIFF
--- a/core/wallet-ui-components/src/windows/popup.test.ts
+++ b/core/wallet-ui-components/src/windows/popup.test.ts
@@ -85,4 +85,45 @@ describe('popup', () => {
         expect(openSpy).toHaveBeenCalledTimes(1)
         expect(mockWin.location.href).toBe('https://second.example')
     })
+
+    it('includes a caller-supplied stylesheet in the popup document head', async () => {
+        const mockWin = createMockPopupWindow()
+        vi.spyOn(window, 'open').mockReturnValue(mockWin as unknown as Window)
+
+        class TestPopupElementWithStylesheet extends HTMLElement {
+            static styles = '.test { color: red; }'
+        }
+        customElements.define(
+            'test-popup-element-with-stylesheet',
+            TestPopupElementWithStylesheet
+        )
+
+        popup.open(TestPopupElementWithStylesheet, {
+            stylesheet: ':root { --wg-theme-primary-color: #123456; }',
+        })
+
+        const html = await (await fetch(mockWin.location.href)).text()
+        expect(html).toContain('--wg-theme-primary-color: #123456')
+    })
+
+    it('neutralizes a literal closing style tag in a caller-supplied stylesheet', async () => {
+        const mockWin = createMockPopupWindow()
+        vi.spyOn(window, 'open').mockReturnValue(mockWin as unknown as Window)
+
+        class TestPopupElementWithUnsafeStylesheet extends HTMLElement {
+            static styles = '.test { color: red; }'
+        }
+        customElements.define(
+            'test-popup-element-with-unsafe-stylesheet',
+            TestPopupElementWithUnsafeStylesheet
+        )
+
+        popup.open(TestPopupElementWithUnsafeStylesheet, {
+            stylesheet: '</style><script>window.__pwned = true</script>',
+        })
+
+        const html = await (await fetch(mockWin.location.href)).text()
+        expect(html).not.toContain('</style><script>')
+        expect(html).toContain('&lt;/style')
+    })
 })

--- a/core/wallet-ui-components/src/windows/popup.ts
+++ b/core/wallet-ui-components/src/windows/popup.ts
@@ -14,6 +14,15 @@ interface PopupOptions {
     height?: number
     screenX?: number
     screenY?: number
+    /**
+     * Extra CSS injected into the popup document's `<head>`, outside the
+     * component's shadow root. Use it to override the `--wg-theme-*` custom
+     * properties (see themes/default.css) that the component's own styles
+     * are built on -- custom properties inherit through the shadow boundary,
+     * so a `:root { --wg-theme-primary-color: ... }` rule here re-themes the
+     * component without needing to know its internal selectors.
+     */
+    stylesheet?: string
 }
 
 interface StyledElement {
@@ -130,10 +139,17 @@ class PopupInstance {
         component: StyledElement,
         options?: PopupOptions
     ): string {
-        const { title = 'Custom Popup' } = options || {}
+        const { title = 'Custom Popup', stylesheet } = options || {}
 
         // Extract and safely escape styles for use in template literal within <script> tag
         const escapedStyles = this.escapeStylesForTemplate(component.styles)
+
+        // Neutralize a literal "</style" in caller-supplied CSS so it can't prematurely
+        // close the <style> tag it's injected into below.
+        const safeStylesheet = (stylesheet ?? '').replace(
+            /<\/style/gi,
+            '&lt;/style'
+        )
 
         // Get serialized component and remove any static styles assignments
         // This prevents minification issues where identifiers get renamed
@@ -159,6 +175,8 @@ class PopupInstance {
                 body {
                     display: flex;
                 }
+
+                ${safeStylesheet}
             </style>
         </head>
         <body>

--- a/core/wallet-ui-components/src/windows/wallet-picker.stories.ts
+++ b/core/wallet-ui-components/src/windows/wallet-picker.stories.ts
@@ -93,6 +93,26 @@ export const Popup: StoryObj = {
         </button>`,
 }
 
+const CUSTOM_STYLESHEET = `
+    :root {
+        --wg-theme-primary-color: #6366f1;
+        --wg-theme-background-color: #0f172a;
+        --wg-theme-text-color: #f8fafc;
+        --wg-theme-border-color: #334155;
+    }
+`
+
+export const PopupWithCustomStylesheet: StoryObj = {
+    render: () =>
+        html`<button
+            class="btn btn-primary"
+            @click=${() =>
+                pickWallet(MOCK_ENTRIES, { stylesheet: CUSTOM_STYLESHEET })}
+        >
+            Connect Wallet (custom theme)
+        </button>`,
+}
+
 export const Empty: StoryObj = {
     render: () => {
         localStorage.removeItem('splice_wallet_picker_entries')

--- a/core/wallet-ui-components/src/windows/wallet-picker.ts
+++ b/core/wallet-ui-components/src/windows/wallet-picker.ts
@@ -112,6 +112,15 @@ export const waitForWalletPickerRetrySelection =
         return await awaitWalletPickerSelection(win)
     }
 
+export type PickWalletOptions = {
+    /**
+     * Extra CSS applied to the wallet picker popup, e.g. to override the
+     * `--wg-theme-*` custom properties for a custom theme. See
+     * PopupOptions.stylesheet for details.
+     */
+    stylesheet?: string
+}
+
 /**
  * Opens a wallet picker popup and resolves with the user's selection.
  *
@@ -119,7 +128,8 @@ export const waitForWalletPickerRetrySelection =
  * communicated back via postMessage.
  */
 export async function pickWallet(
-    entries: WalletPickerEntry[]
+    entries: WalletPickerEntry[],
+    options?: PickWalletOptions
 ): Promise<WalletPickerResult> {
     localStorage.setItem(
         'splice_wallet_picker_entries',
@@ -128,6 +138,9 @@ export async function pickWallet(
 
     const win = popup.open(WalletPicker, {
         title: 'Connect a wallet',
+        ...(options?.stylesheet !== undefined
+            ? { stylesheet: options.stylesheet }
+            : {}),
     })
     activeWalletPickerWindow = win
 

--- a/sdk/dapp-sdk/src/sdk.ts
+++ b/sdk/dapp-sdk/src/sdk.ts
@@ -88,9 +88,23 @@ export class DappSDK {
     private dynamicAdapterIds = new Set<string>()
     private configuredAdapters: DappSDKConnectOptions | undefined
 
-    constructor(options?: { walletPicker?: WalletPickerFn | undefined }) {
+    constructor(options?: {
+        walletPicker?: WalletPickerFn | undefined
+        /**
+         * Extra CSS applied to the default wallet picker popup (e.g. to
+         * override the `--wg-theme-*` custom properties for a custom theme).
+         * Ignored if a custom `walletPicker` is supplied instead.
+         */
+        walletPickerStylesheet?: string | undefined
+    }) {
         this.walletPicker =
-            options?.walletPicker ?? (pickWallet as WalletPickerFn)
+            options?.walletPicker ??
+            ((entries: WalletPickerEntry[]) =>
+                pickWallet(entries, {
+                    ...(options?.walletPickerStylesheet !== undefined
+                        ? { stylesheet: options.walletPickerStylesheet }
+                        : {}),
+                }))
     }
 
     private async registerAdapters(


### PR DESCRIPTION
## Summary

The wallet picker popup (opened via \`pickWallet\`, the default \`walletPicker\` for \`DappSDK\`) renders as a Lit custom element inside an isolated popup window, themed entirely through \`--wg-theme-*\` CSS custom properties (\`themes/default.css\`). Since it's a separate browsing context, a dApp implementer had no way to affect that theming -- setting those properties on their own page has no effect on a completely separate window/document.

Added an optional \`stylesheet\` to \`PopupOptions\` (\`core/wallet-ui-components/src/windows/popup.ts\`), injected as CSS text into the popup document's own \`<head>\`, outside the component's shadow root. Custom properties inherit through the shadow boundary by spec, so a \`:root { --wg-theme-primary-color: ... }\` rule there re-themes the component without needing to know its internal selectors.

Threaded through the existing call chain:
- \`popup.open(component, { stylesheet })\`
- \`pickWallet(entries, { stylesheet })\` (new \`PickWalletOptions\`)
- \`new DappSDK({ walletPickerStylesheet })\` (ignored if a custom \`walletPicker\` is supplied, since that bypasses the default popup entirely)

Related to #609. Fixes #1151

## Test plan

- [x] \`tsc --noEmit\` in \`core/wallet-ui-components\` and \`sdk/dapp-sdk\`: same pre-existing error count before/after (32 and 62 respectively -- both from unbuilt workspace deps, unrelated to this change), confirmed via before/after \`git stash\` comparison
- [x] \`eslint\` / \`prettier --check\` clean on all 5 changed files
- [x] Existing \`popup.test.ts\` / \`wallet-picker.test.ts\` suites (10 tests) pass unchanged
- [x] Added 2 new tests to \`popup.test.ts\`: one fetches the generated popup blob and confirms the custom stylesheet text actually lands in the document, the other confirms a literal \`</style\` in caller-supplied CSS can't break out of the \`<style>\` tag it's injected into
- [x] Added a \`PopupWithCustomStylesheet\` story to \`wallet-picker.stories.ts\` demonstrating a dark custom theme