### PR TITLE
Exclude test-utils.ts from package build output

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,6 +17,7 @@
         "${configDir}/build",
         "${configDir}/**/*.spec.ts",
         "${configDir}/**/*.test.ts",
-        "${configDir}/**/__tests__/**"
+        "${configDir}/**/__tests__/**",
+        "${configDir}/**/test-utils.ts"
     ]
 }


### PR DESCRIPTION
## Summary

`core/splice-client/dist/test-utils.d.ts` (and `core/ledger-client`'s equivalent) are checked into git. The shared `tsconfig.base.json` exclude list already catches `*.test.ts`, `*.spec.ts`, and `__tests__/**`, but not a file literally named `test-utils.ts`.

Added `**/test-utils.ts` to the shared exclude.

Deliberately did **not** exclude `fixtures.ts`/`mocks.ts` more broadly: `core/wallet-test-utils` intentionally exports `fixtures.ts` as part of its real public API (`main`/`module`/`types` all point at `dist/index.*`, and `index.ts` does `export { test, expect } from './fixtures.js'`), so a blanket filename-based exclude there would break that package's actual build output.

Fixes #1899

## Test plan

- [x] Rebuilt `core/splice-client`'s declarations twice: with this change, `test-utils.d.ts`/`.d.ts.map` are absent from `dist/`; reverting the change and rebuilding again, they reappear -- confirms this fix is what causes the difference, not something else
- [x] Confirmed via `grep` that no file anywhere in the repo imports from a `test-utils.ts` path, so nothing depends on it being in the build output