### PR TITLE
test: dapp sdk unit test improvements

### DIFF
--- a/sdk/dapp-sdk/src/adapter/extension-adapter.test.ts
+++ b/sdk/dapp-sdk/src/adapter/extension-adapter.test.ts
@@ -1,31 +1,11 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    afterEach,
-    beforeEach,
-    describe,
-    expect,
-    it,
-    vi,
-    type Mock,
-} from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { WalletEvent } from '@canton-network/core-types'
-import type { Provider } from '@canton-network/core-splice-provider'
-import type { RpcTypes as DappRpcTypes } from '@canton-network/core-wallet-dapp-rpc-client'
 import * as storage from '../storage'
+import { makeMockProvider } from '../test-utils'
 import { ExtensionAdapter } from './extension-adapter'
-
-type MockProvider = {
-    request: Mock<Provider<DappRpcTypes>['request']>
-}
-
-const makeMockProvider = (): MockProvider => ({
-    request: vi.fn(),
-})
-
-const asProvider = (mock: MockProvider): Provider<DappRpcTypes> =>
-    mock as unknown as Provider<DappRpcTypes>
 
 describe('ExtensionAdapter', () => {
     beforeEach(() => {
@@ -121,14 +101,14 @@ describe('ExtensionAdapter', () => {
                 isNetworkConnected: true,
             },
         })
-        vi.spyOn(adapter, 'provider').mockReturnValue(asProvider(mockProvider))
+        vi.spyOn(adapter, 'provider').mockReturnValue(mockProvider)
 
         storage.setKernelDiscovery({
             walletType: 'extension',
             providerId: 'browser:ext:test',
         })
 
-        await expect(adapter.restore()).resolves.toBe(asProvider(mockProvider))
+        await expect(adapter.restore()).resolves.toBe(mockProvider)
         expect(mockProvider.request).toHaveBeenCalledWith({ method: 'connect' })
         expect(mockProvider.request).toHaveBeenCalledWith({ method: 'status' })
     })
@@ -143,7 +123,7 @@ describe('ExtensionAdapter', () => {
                 isNetworkConnected: false,
             },
         })
-        vi.spyOn(adapter, 'provider').mockReturnValue(asProvider(mockProvider))
+        vi.spyOn(adapter, 'provider').mockReturnValue(mockProvider)
 
         await expect(adapter.restore()).resolves.toBeNull()
     })

--- a/sdk/dapp-sdk/src/adapter/extension-adapter.test.ts
+++ b/sdk/dapp-sdk/src/adapter/extension-adapter.test.ts
@@ -12,24 +12,13 @@ import {
 } from 'vitest'
 import { WalletEvent } from '@canton-network/core-types'
 import type { Provider } from '@canton-network/core-splice-provider'
-import type {
-    RpcTypes as DappRpcTypes,
-    StatusEvent,
-} from '@canton-network/core-wallet-dapp-rpc-client'
+import type { RpcTypes as DappRpcTypes } from '@canton-network/core-wallet-dapp-rpc-client'
 import * as storage from '../storage'
 import { ExtensionAdapter } from './extension-adapter'
 
 type MockProvider = {
     request: Mock<Provider<DappRpcTypes>['request']>
 }
-
-const connectedStatus = (): StatusEvent => ({
-    provider: { id: 'browser:ext:test' },
-    connection: {
-        isConnected: true,
-        isNetworkConnected: true,
-    },
-})
 
 const makeMockProvider = (): MockProvider => ({
     request: vi.fn(),
@@ -125,7 +114,13 @@ describe('ExtensionAdapter', () => {
             providerId: 'browser:ext:test',
         })
         const mockProvider = makeMockProvider()
-        mockProvider.request.mockResolvedValue(connectedStatus())
+        mockProvider.request.mockResolvedValue({
+            provider: { id: 'browser:ext:test' },
+            connection: {
+                isConnected: true,
+                isNetworkConnected: true,
+            },
+        })
         vi.spyOn(adapter, 'provider').mockReturnValue(asProvider(mockProvider))
 
         storage.setKernelDiscovery({

--- a/sdk/dapp-sdk/src/adapter/remote-adapter.test.ts
+++ b/sdk/dapp-sdk/src/adapter/remote-adapter.test.ts
@@ -242,6 +242,7 @@ describe('RemoteAdapter', () => {
             'statusChanged',
             kernelSession()
         )
+        expect(listener).toHaveBeenCalledWith(kernelSession())
     })
 
     it('persists kernel session when statusChanged includes a session', () => {
@@ -285,6 +286,18 @@ describe('RemoteAdapter', () => {
     })
 
     describe('restore', () => {
+        // When another wallet was picked, the adapter must not restore
+        // anything, even with a kernel session stored.
+        it('returns null when the stored discovery is not a remote wallet', async () => {
+            storage.setKernelDiscovery({
+                walletType: 'extension',
+                providerId: 'browser:ext:test',
+            })
+            storage.setKernelSession(kernelSession())
+
+            await expect(adapter.restore()).resolves.toBeNull()
+        })
+
         it('returns null when discovery does not match this gateway', async () => {
             storage.setKernelDiscovery({
                 walletType: 'remote',

--- a/sdk/dapp-sdk/src/adapter/remote-adapter.test.ts
+++ b/sdk/dapp-sdk/src/adapter/remote-adapter.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { WalletEvent } from '@canton-network/core-types'
 import { popup } from '@canton-network/core-wallet-ui-components'
 import type { EventListener } from '@canton-network/core-splice-provider'
@@ -90,6 +90,10 @@ vi.mock('@canton-network/core-wallet-ui-components', () => ({
     },
 }))
 
+// A connected gateway session as reported by the wallet kernel: the payload a
+// dapp gets from `status`/`statusChanged` once the user logged into the
+// gateway at RPC_URL. Always a new copy, to avoid undesired mutations from
+// other tests.
 const kernelSession = (): StatusEvent => ({
     provider: {
         id: 'remote-gateway',
@@ -107,9 +111,15 @@ const kernelSession = (): StatusEvent => ({
 })
 
 describe('RemoteAdapter', () => {
+    // Shared instance built fresh per test. Safe to construct before each
+    // test sets up its own storage state: the constructor only copies config,
+    // storage is read lazily by provider() and restore().
+    let adapter: RemoteAdapter
+
     beforeEach(() => {
         localStorage.clear()
         vi.clearAllMocks()
+        adapter = new RemoteAdapter({ name: 'Gateway', rpcUrl: RPC_URL })
         mockController.status.mockResolvedValue(kernelSession())
         mockController.connect.mockResolvedValue(kernelSession().connection)
         mockController.disconnect.mockResolvedValue(null)
@@ -123,16 +133,7 @@ describe('RemoteAdapter', () => {
         mockController.ledgerApi.mockResolvedValue({ ok: true })
     })
 
-    afterEach(() => {
-        vi.restoreAllMocks()
-    })
-
     it('derives providerId from rpcUrl by default', () => {
-        const adapter = new RemoteAdapter({
-            name: 'Gateway',
-            rpcUrl: RPC_URL,
-        })
-
         expect(adapter.providerId).toBe(`remote:${RPC_URL}`)
         expect(adapter.getInfo()).toEqual({
             providerId: `remote:${RPC_URL}`,
@@ -146,15 +147,12 @@ describe('RemoteAdapter', () => {
     })
 
     it('always reports the gateway as available', async () => {
-        await expect(
-            new RemoteAdapter({ name: 'Gateway', rpcUrl: RPC_URL }).detect()
-        ).resolves.toBe(true)
+        await expect(adapter.detect()).resolves.toBe(true)
     })
 
     it('creates a mapped provider backed by DappAsyncProvider', async () => {
         storage.setKernelSession(kernelSession())
 
-        const adapter = new RemoteAdapter({ name: 'Gateway', rpcUrl: RPC_URL })
         const provider = adapter.provider()
 
         expect(dappSDKControllerMock).not.toHaveBeenCalled()
@@ -166,7 +164,6 @@ describe('RemoteAdapter', () => {
     })
 
     it('routes RPC calls through dappSDKController', async () => {
-        const adapter = new RemoteAdapter({ name: 'Gateway', rpcUrl: RPC_URL })
         const provider = adapter.provider()
 
         mockController.status.mockResolvedValueOnce(kernelSession())
@@ -231,7 +228,6 @@ describe('RemoteAdapter', () => {
     })
 
     it('forwards provider events to the remote provider', () => {
-        const adapter = new RemoteAdapter({ name: 'Gateway', rpcUrl: RPC_URL })
         const provider = adapter.provider()
         const listener = vi.fn<EventListener<StatusEvent>>()
 
@@ -249,7 +245,6 @@ describe('RemoteAdapter', () => {
     })
 
     it('persists kernel session when statusChanged includes a session', () => {
-        const adapter = new RemoteAdapter({ name: 'Gateway', rpcUrl: RPC_URL })
         adapter.provider()
 
         mockDappAsyncProvider.emitToListeners('statusChanged', kernelSession())
@@ -258,7 +253,6 @@ describe('RemoteAdapter', () => {
     })
 
     it('clears local state when statusChanged reports a disconnect', () => {
-        const adapter = new RemoteAdapter({ name: 'Gateway', rpcUrl: RPC_URL })
         adapter.provider()
 
         mockDappAsyncProvider.emitToListeners('statusChanged', {
@@ -273,7 +267,6 @@ describe('RemoteAdapter', () => {
     })
 
     it('clears local state when the wallet gateway logs out', () => {
-        const adapter = new RemoteAdapter({ name: 'Gateway', rpcUrl: RPC_URL })
         adapter.provider()
 
         window.dispatchEvent(
@@ -286,7 +279,7 @@ describe('RemoteAdapter', () => {
     })
 
     it('closes the popup on teardown', () => {
-        new RemoteAdapter({ name: 'Gateway', rpcUrl: RPC_URL }).teardown()
+        adapter.teardown()
 
         expect(popup.close).toHaveBeenCalled()
     })
@@ -299,10 +292,6 @@ describe('RemoteAdapter', () => {
             })
             storage.setKernelSession(kernelSession())
 
-            const adapter = new RemoteAdapter({
-                name: 'Gateway',
-                rpcUrl: RPC_URL,
-            })
             await expect(adapter.restore()).resolves.toBeNull()
         })
 
@@ -312,10 +301,6 @@ describe('RemoteAdapter', () => {
                 url: RPC_URL,
             })
 
-            const adapter = new RemoteAdapter({
-                name: 'Gateway',
-                rpcUrl: RPC_URL,
-            })
             await expect(adapter.restore()).resolves.toBeNull()
         })
 
@@ -326,10 +311,6 @@ describe('RemoteAdapter', () => {
             })
             storage.setKernelSession(kernelSession())
 
-            const adapter = new RemoteAdapter({
-                name: 'Gateway',
-                rpcUrl: RPC_URL,
-            })
             const restored = await adapter.restore()
 
             expect(restored).not.toBeNull()

--- a/sdk/dapp-sdk/src/adapter/walletconnect-adapter.test.ts
+++ b/sdk/dapp-sdk/src/adapter/walletconnect-adapter.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { EventListener } from '@canton-network/core-splice-provider'
 import type { StatusEvent } from '@canton-network/core-wallet-dapp-rpc-client'
 import { WALLETCONNECT_ICON } from '../assets'
@@ -10,17 +10,19 @@ import {
     type WalletConnectAdapterConfig,
 } from './walletconnect-adapter'
 
-const mockSession = {
-    topic: 'session-topic',
-    namespaces: {
-        canton: {
-            accounts: ['account'],
-        },
-    },
-}
+const { mockSession, mockSignClient, SignClientInit, sessionEventHandler } =
+    vi.hoisted(() => {
+        // An approved WalletConnect session holding a canton namespace, the
+        // shape restore() looks for among the SignClient's persisted sessions.
+        const mockSession = {
+            topic: 'session-topic',
+            namespaces: {
+                canton: {
+                    accounts: ['account'],
+                },
+            },
+        }
 
-const { mockSignClient, SignClientInit, sessionEventHandler } = vi.hoisted(
-    () => {
         let sessionEventHandler:
             | ((event: {
                   params: { event: { name: string; data: unknown } }
@@ -28,7 +30,10 @@ const { mockSignClient, SignClientInit, sessionEventHandler } = vi.hoisted(
             | undefined
 
         const mockSignClient = {
-            connect: vi.fn(),
+            connect: vi.fn().mockResolvedValue({
+                uri: 'wc:test-uri',
+                approval: vi.fn().mockResolvedValue(mockSession),
+            }),
             request: vi.fn(),
             disconnect: vi.fn(),
             on: vi.fn((event: string, handler: (arg: unknown) => void) => {
@@ -40,12 +45,12 @@ const { mockSignClient, SignClientInit, sessionEventHandler } = vi.hoisted(
         }
 
         return {
+            mockSession,
             mockSignClient,
             SignClientInit: vi.fn().mockResolvedValue(mockSignClient),
             sessionEventHandler: () => sessionEventHandler,
         }
-    }
-)
+    })
 
 vi.mock('@walletconnect/sign-client', () => ({
     default: {
@@ -73,15 +78,6 @@ const makeAdapter = (
 describe('WalletConnectAdapter', () => {
     beforeEach(() => {
         vi.clearAllMocks()
-        mockSignClient.session.getAll.mockReturnValue([])
-        mockSignClient.connect.mockResolvedValue({
-            uri: 'wc:test-uri',
-            approval: vi.fn().mockResolvedValue(mockSession),
-        })
-    })
-
-    afterEach(() => {
-        vi.restoreAllMocks()
     })
 
     it('exposes wallet picker metadata', () => {
@@ -203,7 +199,7 @@ describe('WalletConnectAdapter', () => {
     })
 
     it('restores an existing Canton WalletConnect session', async () => {
-        mockSignClient.session.getAll.mockReturnValue([mockSession])
+        mockSignClient.session.getAll.mockReturnValueOnce([mockSession])
 
         const adapter = makeAdapter()
         const restored = await adapter.restore()
@@ -216,7 +212,7 @@ describe('WalletConnectAdapter', () => {
     })
 
     it('forwards session events to local listeners', async () => {
-        mockSignClient.session.getAll.mockReturnValue([mockSession])
+        mockSignClient.session.getAll.mockReturnValueOnce([mockSession])
         const adapter = makeAdapter()
         const listener = vi.fn()
 
@@ -316,5 +312,8 @@ describe('WalletConnectAdapter', () => {
             expect.any(Object),
             '*'
         )
+
+        // Resets real window.open behavior
+        windowSpy.mockRestore()
     })
 })

--- a/sdk/dapp-sdk/src/announce-discovery.test.ts
+++ b/sdk/dapp-sdk/src/announce-discovery.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
     CANTON_ANNOUNCE_PROVIDER_EVENT,
     CANTON_REQUEST_PROVIDER_EVENT,
@@ -9,7 +9,12 @@ import {
 import { requestAnnouncedProviders } from './announce-discovery'
 
 describe('requestAnnouncedProviders', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
     afterEach(() => {
+        vi.useRealTimers()
         vi.restoreAllMocks()
     })
 
@@ -45,6 +50,8 @@ describe('requestAnnouncedProviders', () => {
             // no name
         })
 
+        await vi.advanceTimersByTimeAsync(50)
+
         await expect(promise).resolves.toEqual([
             {
                 id: 'ext-1',
@@ -66,7 +73,9 @@ describe('requestAnnouncedProviders', () => {
         const removeListenerSpy = vi.spyOn(window, 'removeEventListener')
 
         // this keeps pending until the timeout passes
-        await requestAnnouncedProviders({ timeoutMs: 10 })
+        const promise = requestAnnouncedProviders({ timeoutMs: 10 })
+        await vi.advanceTimersByTimeAsync(10)
+        await promise
 
         const announceHandler = addListenerSpy.mock.calls.find(
             ([event]) => event === CANTON_ANNOUNCE_PROVIDER_EVENT

--- a/sdk/dapp-sdk/src/client.test.ts
+++ b/sdk/dapp-sdk/src/client.test.ts
@@ -1,17 +1,16 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { WalletEvent } from '@canton-network/core-types'
 import { popup } from '@canton-network/core-wallet-ui-components'
-import type { Provider } from '@canton-network/core-splice-provider'
 import type {
     LedgerApiParams,
     PrepareExecuteParams,
-    RpcTypes as DappRpcTypes,
     SignMessageParams,
 } from '@canton-network/core-wallet-dapp-rpc-client'
 import { DappClient } from './client'
+import { makeMockProvider } from './test-utils'
 import * as util from './util'
 
 vi.mock('./util', () => ({
@@ -24,23 +23,6 @@ vi.mock('@canton-network/core-wallet-ui-components', () => ({
         close: vi.fn(),
     },
 }))
-
-type MockDappProvider = {
-    request: Mock<Provider<DappRpcTypes>['request']>
-    on: Mock<Provider<DappRpcTypes>['on']>
-    removeListener: Mock<Provider<DappRpcTypes>['removeListener']>
-}
-
-const makeProvider = (): MockDappProvider => ({
-    request: vi.fn(),
-    on: vi.fn(),
-    removeListener: vi.fn(),
-})
-
-// MockDappProvider when calling vitest mocking methods
-// Provider<DappRpcTypes> when passing to source code methods
-const asProvider = (mock: MockDappProvider): Provider<DappRpcTypes> =>
-    mock as unknown as Provider<DappRpcTypes>
 
 const prepareExecuteParams: PrepareExecuteParams = { commands: [] }
 const signMessageParams: SignMessageParams = { message: 'hello' }
@@ -55,14 +37,14 @@ describe('DappClient', () => {
     })
 
     it('exposes the underlying provider', () => {
-        const mock = makeProvider()
-        const client = new DappClient(asProvider(mock))
+        const mock = makeMockProvider()
+        const client = new DappClient(mock)
 
         expect(client.getProvider()).toBe(mock)
     })
 
     it('delegates RPC calls to the provider', async () => {
-        const mock = makeProvider()
+        const mock = makeMockProvider()
         mock.request.mockImplementation(async ({ method }) => {
             switch (method) {
                 case 'connect':
@@ -86,7 +68,7 @@ describe('DappClient', () => {
             }
         })
 
-        const client = new DappClient(asProvider(mock))
+        const client = new DappClient(mock)
 
         await expect(client.connect()).resolves.toEqual({ isConnected: true })
         await expect(client.status()).resolves.toEqual({
@@ -111,8 +93,8 @@ describe('DappClient', () => {
     })
 
     it('registers and removes event listeners on the provider', () => {
-        const mock = makeProvider()
-        const client = new DappClient(asProvider(mock))
+        const mock = makeMockProvider()
+        const client = new DappClient(mock)
         const listener = vi.fn()
 
         client.onStatusChanged(listener)
@@ -150,12 +132,12 @@ describe('DappClient', () => {
     })
 
     it('opens the wallet popup for remote providers', async () => {
-        const mock = makeProvider()
+        const mock = makeMockProvider()
         mock.request.mockResolvedValue({
             provider: { userUrl: 'https://wallet.example.com/user' },
         })
 
-        const client = new DappClient(asProvider(mock))
+        const client = new DappClient(mock)
         await client.open()
 
         expect(popup.open).toHaveBeenCalledWith(
@@ -164,13 +146,13 @@ describe('DappClient', () => {
     })
 
     it('posts an extension open message for browser providers', async () => {
-        const mock = makeProvider()
+        const mock = makeMockProvider()
         mock.request.mockResolvedValue({
             provider: { userUrl: 'https://wallet.example.com/user' },
         })
         const postMessageSpy = vi.spyOn(window, 'postMessage')
 
-        const client = new DappClient(asProvider(mock), {
+        const client = new DappClient(mock, {
             providerType: 'browser',
             target: 'extension-target',
         })
@@ -187,20 +169,20 @@ describe('DappClient', () => {
     })
 
     it('throws when status does not include a user URL', async () => {
-        const mock = makeProvider()
+        const mock = makeMockProvider()
         mock.request.mockResolvedValue({ provider: {} })
 
-        const client = new DappClient(asProvider(mock))
+        const client = new DappClient(mock)
         await expect(client.open()).rejects.toThrow(
             'User URL not found in status'
         )
     })
 
     it('disconnects and clears local state even when the RPC fails', async () => {
-        const mock = makeProvider()
+        const mock = makeMockProvider()
         mock.request.mockRejectedValue(new Error('disconnect failed'))
 
-        const client = new DappClient(asProvider(mock))
+        const client = new DappClient(mock)
         await expect(client.disconnect()).rejects.toThrow('disconnect failed')
 
         expect(util.clearAllLocalState).toHaveBeenCalledWith({

--- a/sdk/dapp-sdk/src/storage.test.ts
+++ b/sdk/dapp-sdk/src/storage.test.ts
@@ -48,29 +48,19 @@ describe('storage', () => {
     })
 
     describe('kernel discovery', () => {
-        it('round-trips remote discovery through localStorage', () => {
-            setKernelDiscovery({
-                walletType: 'remote',
-                url: 'https://gateway.example.com',
-            })
+        // Each DiscoverResult variant is validated by a different zod schema
+        // branch, so each one gets its own round-trip case.
+        it.each([
+            { walletType: 'remote', url: 'https://gateway.example.com' },
+            { walletType: 'extension', providerId: 'browser:ext:abc' },
+        ] as const)(
+            'round-trips $walletType discovery through localStorage',
+            (discovery) => {
+                setKernelDiscovery(discovery)
 
-            expect(getKernelDiscovery()).toEqual({
-                walletType: 'remote',
-                url: 'https://gateway.example.com',
-            })
-        })
-
-        it('round-trips extension discovery through localStorage', () => {
-            setKernelDiscovery({
-                walletType: 'extension',
-                providerId: 'browser:ext:abc',
-            })
-
-            expect(getKernelDiscovery()).toEqual({
-                walletType: 'extension',
-                providerId: 'browser:ext:abc',
-            })
-        })
+                expect(getKernelDiscovery()).toEqual(discovery)
+            }
+        )
 
         it('returns undefined for invalid stored discovery', () => {
             const errorSpy = vi

--- a/sdk/dapp-sdk/src/test-utils.ts
+++ b/sdk/dapp-sdk/src/test-utils.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { vi, type Mock } from 'vitest'
+import type { Provider } from '@canton-network/core-splice-provider'
+import type { RpcTypes as DappRpcTypes } from '@canton-network/core-wallet-dapp-rpc-client'
+
+/**
+ * A dapp provider mock that is also assignable to Provider<DappRpcTypes>,
+ * so tests can pass it to source code directly and still call vitest mock
+ * methods (mockResolvedValue, toHaveBeenCalledWith, ...) on its members
+ * without casting.
+ */
+
+export type MockProvider = Provider<DappRpcTypes> & {
+    request: Mock<Provider<DappRpcTypes>['request']>
+    on: Mock<Provider<DappRpcTypes>['on']>
+    removeListener: Mock<Provider<DappRpcTypes>['removeListener']>
+}
+
+export const makeMockProvider = (): MockProvider =>
+    ({
+        request: vi.fn(),
+        on: vi.fn(),
+        removeListener: vi.fn(),
+    }) as unknown as MockProvider

--- a/sdk/dapp-sdk/vitest.config.ts
+++ b/sdk/dapp-sdk/vitest.config.ts
@@ -9,7 +9,11 @@ export default defineConfig({
         globalSetup: ['./vitest.global-setup.ts'],
         coverage: {
             include: ['src/**/*.ts'],
-            exclude: ['src/integration-test/**', 'src/dapp-api/rpc-gen/**'],
+            exclude: [
+                'src/integration-test/**',
+                'src/dapp-api/rpc-gen/**',
+                'src/test-utils.ts',
+            ],
             provider: 'v8',
             reporter: ['text', 'html', 'lcov', 'json-summary'],
             thresholds: {


### PR DESCRIPTION
## What

Closes #2027.

Resolves the 16 review comments from #1992 that were deferred to that issue, numbered here in the order they are listed there. Everything is test code in `sdk/dapp-sdk`; no production behavior changes. Comments [#1](https://github.com/canton-network/wallet/pull/1992#discussion_r3420473960), [#3](https://github.com/canton-network/wallet/pull/1992#discussion_r3420984118) and [#4](https://github.com/canton-network/wallet/pull/1992#discussion_r3420989153) were already resolved in main; the rest are addressed below.

## What we changed

1. **Shared provider mock** ([#2](https://github.com/canton-network/wallet/pull/1992#discussion_r3420939135), [#5](https://github.com/canton-network/wallet/pull/1992#discussion_r3421068910), [#16](https://github.com/canton-network/wallet/pull/1992#discussion_r3427525345)). `client.test.ts` and `extension-adapter.test.ts` each had their own copy of the same provider mock plus an `asProvider` cast to hand it to source code. Both now use a single `makeMockProvider()` from `src/test-utils.ts`, whose return type is directly assignable to `Provider<DappRpcTypes>`, so the cast is gone. The helper is excluded from coverage, same as the existing `test-utils.ts` in `splice-client` and `ledger-client`. 
**Comment:** #5 suggested a single `vi.hoisted` mock instead of a per-test factory, relying on `vi.restoreAllMocks()` to reset it; in the vitest version we run (4.x), `restoreAllMocks` only restores `vi.spyOn` spies and does not touch `vi.fn()` mocks at all, so a shared instance would leak state between tests.
2. **remote-adapter.test.ts** ([#7](https://github.com/canton-network/wallet/pull/1992#discussion_r3421413659), [#8](https://github.com/canton-network/wallet/pull/1992#discussion_r3421447242), [#9](https://github.com/canton-network/wallet/pull/1992#discussion_r3421482383), [#10](https://github.com/canton-network/wallet/pull/1992#discussion_r3421549567), [#11](https://github.com/canton-network/wallet/pull/1992#discussion_r3421607456)). The `RemoteAdapter` is now built once in `beforeEach` instead of in every test (safe: the constructor only copies config, storage is read lazily). Dropped the `afterEach(vi.restoreAllMocks)`, which had nothing to restore since the file has no `vi.spyOn`. Two coverage additions: the event-forwarding test now asserts the listener actually received the payload, and `restore()` has a new test for the guard where the stored discovery points to another wallet type.
3. **walletconnect-adapter.test.ts** ([#12](https://github.com/canton-network/wallet/pull/1992#discussion_r3426888401), [#13](https://github.com/canton-network/wallet/pull/1992#discussion_r3426894623)). The SignClient mock's default behavior is programmed once in the `vi.hoisted` block instead of before every test; the two restore tests switch to `mockReturnValueOnce` so their scenario cannot leak into later tests now that nothing re-programs the defaults. Dropped the `afterEach(vi.restoreAllMocks)` here too; its only remaining effect was un-spying `window.open`, so the popup test that creates that spy now restores it itself.
4. **announce-discovery.test.ts** ([#15](https://github.com/canton-network/wallet/pull/1992#discussion_r3427229071)). The tests waited real time for the collection window (50ms and 10ms per run). They now use fake timers and advance the clock explicitly, so they are instant and immune to timing flakiness.
5. **storage.test.ts** ([#6](https://github.com/canton-network/wallet/pull/1992#discussion_r3421344921)). The two discovery round-trip tests looked identical but were not duplicates: each covers one branch of the `DiscoverResult` discriminated union (`remote` with `url`, `extension` with `providerId`). They are now a single `it.each` with one case per variant, which makes that intent explicit.
6. **Not addressed here: `WalletConnectAdapter.create` vs public constructor** ([#14](https://github.com/canton-network/wallet/pull/1992#discussion_r3426899858)). Today the SDK exposes two identical ways to build the adapter. Whether to deprecate `.create`, privatize the constructor, or document why both exist is a public API decision for the project and exceeds this PR. Once decided, the tests will need to be adjusted accordingly.

Contributed by [bootnode.dev](http://bootnode.dev/)