### PR TITLE
feat: add timeout to detectCurrentOrigin() to avoid hanging forever

### DIFF
--- a/wallet-gateway/remote/src/web/frontend/constants.ts
+++ b/wallet-gateway/remote/src/web/frontend/constants.ts
@@ -9,3 +9,4 @@ export const NETWORKS_PAGE_REDIRECT = '/networks'
 export const IDENTITY_PROVIDERS_PAGE_REDIRECT = '/identity-providers'
 
 export const TOKEN_EXPIRED_SKEW_MS = 5000
+export const DETECT_CURRENT_ORIGIN_TIMEOUT_MS = 30000

--- a/wallet-gateway/remote/src/web/frontend/listeners.test.ts
+++ b/wallet-gateway/remote/src/web/frontend/listeners.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DETECT_CURRENT_ORIGIN_TIMEOUT_MS } from './constants.js'
+import { stateManager } from './state-manager.js'
+import { detectCurrentOrigin } from './listeners.js'
+
+const openerOrigin = 'http://opener.example'
+
+describe('detectCurrentOrigin', () => {
+    beforeEach(() => {
+        stateManager.currentOrigin.clear()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.unstubAllGlobals()
+        stateManager.currentOrigin.clear()
+    })
+
+    it('resolves immediately with window.origin when there is no opener', async () => {
+        vi.stubGlobal('opener', null)
+
+        await expect(detectCurrentOrigin()).resolves.toBe(window.origin)
+        expect(stateManager.currentOrigin.get()).toBe(window.origin)
+    })
+
+    it('resolves once the origin-broadcast message sets currentOrigin', async () => {
+        vi.stubGlobal('opener', { closed: false, postMessage: vi.fn() })
+
+        const promise = detectCurrentOrigin()
+        stateManager.currentOrigin.set(openerOrigin)
+
+        await expect(promise).resolves.toBe(openerOrigin)
+    })
+
+    it('rejects if the origin-broadcast message is never received', async () => {
+        vi.useFakeTimers({ shouldAdvanceTime: true })
+        vi.stubGlobal('opener', { closed: false, postMessage: vi.fn() })
+
+        const promise = detectCurrentOrigin()
+        const assertion = expect(promise).rejects.toThrow(
+            `Timed out after ${DETECT_CURRENT_ORIGIN_TIMEOUT_MS}ms waiting for the origin-broadcast message from the opener window`
+        )
+
+        await vi.advanceTimersByTimeAsync(DETECT_CURRENT_ORIGIN_TIMEOUT_MS)
+
+        await assertion
+    })
+})

--- a/wallet-gateway/remote/src/web/frontend/listeners.ts
+++ b/wallet-gateway/remote/src/web/frontend/listeners.ts
@@ -3,6 +3,7 @@
 
 import { isSpliceMessageEvent, WalletEvent } from '@canton-network/core-types'
 import { stateManager } from './state-manager'
+import { DETECT_CURRENT_ORIGIN_TIMEOUT_MS } from './constants'
 
 const handleMessage = (event: MessageEvent) => {
     if (!isSpliceMessageEvent(event)) return
@@ -28,14 +29,24 @@ export async function detectCurrentOrigin(): Promise<string> {
         return window.origin
     }
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
         // wait for stateManager.currentOrigin.get to be defined
         const interval = setInterval(() => {
             const currentOrigin = stateManager.currentOrigin.get()
             if (currentOrigin) {
                 clearInterval(interval)
+                clearTimeout(timeout)
                 resolve(currentOrigin)
             }
         }, 100)
+
+        const timeout = setTimeout(() => {
+            clearInterval(interval)
+            reject(
+                new Error(
+                    `Timed out after ${DETECT_CURRENT_ORIGIN_TIMEOUT_MS}ms waiting for the origin-broadcast message from the opener window`
+                )
+            )
+        }, DETECT_CURRENT_ORIGIN_TIMEOUT_MS)
     })
 }


### PR DESCRIPTION
## Summary

- `detectCurrentOrigin()` (`wallet-gateway/remote/src/web/frontend/listeners.ts`) polls `stateManager.currentOrigin.get()` via `setInterval` while waiting for the opener window's origin-broadcast message, with no timeout or reject path.
- If `window.opener` exists but that message is never received (e.g. the opener never responds), the returned promise hangs forever, and every one of the ~40 call sites across the frontend (`await detectCurrentOrigin()`) hangs with it.
- Added a `DETECT_CURRENT_ORIGIN_TIMEOUT_MS` (30s) timeout that clears the interval and rejects with a descriptive error instead of hanging silently.

Fixes #2228 (the "Consider a timeout for detectCurrentOrigin()" checklist item).

## Test plan

- [x] Added `listeners.test.ts` covering: no-opener resolves immediately, resolves once the broadcast message sets `currentOrigin`, and rejects after the timeout when the message never arrives.
- [x] `npx vitest run --project browser src/web/frontend/listeners.test.ts` — 3/3 passing.
- [x] `eslint` clean on all 3 changed files.
- [x] `tsc --noEmit` clean on the touched files (pre-existing unrelated module-resolution errors in this package come from other packages needing a full monorepo build, not from this change).