### PR TITLE
Re-enable disabled wallets whose party matches a signing provider again

### DIFF
--- a/core/wallet-store-sql/src/schema.ts
+++ b/core/wallet-store-sql/src/schema.ts
@@ -68,6 +68,8 @@ interface UpdateWalletProperties {
     status?: string | null
     disabled?: number
     reason?: string | null
+    signingProviderId?: string
+    publicKey?: string
 }
 
 interface UserPartyRightTable {
@@ -276,6 +278,8 @@ export const toWalletUpdateProperties = (
         disabled,
         reason,
         primary,
+        signingProviderId,
+        publicKey,
     } = params
     return {
         ...(status !== undefined && { status }),
@@ -284,6 +288,8 @@ export const toWalletUpdateProperties = (
         ...(primary !== undefined && { primary: primary ? 1 : 0 }),
         ...(disabled !== undefined && { disabled: disabled ? 1 : 0 }),
         ...(reason !== undefined && { reason }),
+        ...(signingProviderId !== undefined && { signingProviderId }),
+        ...(publicKey !== undefined && { publicKey }),
     }
 }
 

--- a/core/wallet-store/src/Store.ts
+++ b/core/wallet-store/src/Store.ts
@@ -49,6 +49,8 @@ export interface UpdateWallet {
     reason?: string
     primary?: boolean
     rights?: PartyLevelRight[]
+    signingProviderId?: string
+    publicKey?: string
 }
 
 export type WalletStatus = 'initialized' | 'allocated' | 'removed'

--- a/wallet-gateway/remote/src/ledger/wallet-sync-service.test.ts
+++ b/wallet-gateway/remote/src/ledger/wallet-sync-service.test.ts
@@ -1014,6 +1014,57 @@ describe('WalletSyncService - multi-network features', () => {
                 'party2::unknown-namespace-123'
             )
         })
+
+        it('syncWallets re-enables a disabled wallet once its party matches a signing provider again', async () => {
+            const network1 = createNetwork('network1')
+            await store.addNetwork(network1)
+            await setSession('network1')
+            const disabledWallet = createWallet(
+                'party1::namespace',
+                'network1',
+                true
+            )
+            await store.addWallet(disabledWallet)
+
+            mockLedgerGet
+                .mockResolvedValueOnce({
+                    participantId: 'participant1::namespace',
+                })
+                .mockResolvedValueOnce({
+                    rights: [
+                        {
+                            kind: {
+                                CanActAs: {
+                                    value: { party: 'party1::namespace' },
+                                },
+                            },
+                        },
+                    ],
+                })
+
+            const updateWalletSpy = vi.spyOn(store, 'updateWallet')
+            const addWalletSpy = vi.spyOn(store, 'addWallet')
+
+            const result = await service.syncWallets()
+
+            expect(addWalletSpy).not.toHaveBeenCalled()
+            expect(updateWalletSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    partyId: 'party1::namespace',
+                    networkId: 'network1',
+                    disabled: false,
+                })
+            )
+            const wallets = await store.getWallets()
+            const party1Wallet = wallets.find(
+                (w) => w.partyId === 'party1::namespace'
+            )
+            expect(party1Wallet?.disabled).toBe(false)
+            expect(result.added.length).toBe(0)
+            expect(result.updated.length).toBe(1)
+            expect(result.updated[0].partyId).toBe('party1::namespace')
+            expect(result.disabled.length).toBe(0)
+        })
     })
 
     describe('Wallet sync - rights tracking', () => {

--- a/wallet-gateway/remote/src/ledger/wallet-sync-service.ts
+++ b/wallet-gateway/remote/src/ledger/wallet-sync-service.ts
@@ -391,14 +391,23 @@ export class WalletSyncService {
         }
     }
 
-    // Creates wallets for parties user has rights to
+    // Creates wallets for parties user has rights to. A party may already
+    // have a wallet row that's disabled (e.g. from a prior sync where its
+    // signing provider didn't match) -- store.addWallet() throws on a
+    // duplicate (partyId, networkId), so those go through updateWallet()
+    // instead, re-resolving the signing provider so the wallet can come
+    // back out of its disabled state.
     private async handlePartiesWithoutWallet(
         newParties: string[],
         networkId: string,
         rightsByParty: Map<string, PartyLevelRight[]>,
-        participantNamespace: string
-    ): Promise<Wallet[]> {
-        return await Promise.all(
+        participantNamespace: string,
+        existingWalletsByParty: Map<string, Wallet>
+    ): Promise<{ added: Wallet[]; reEnabled: Wallet[] }> {
+        const added: Wallet[] = []
+        const reEnabled: Wallet[] = []
+
+        await Promise.all(
             newParties.map(async (partyId) => {
                 const [hint, namespace] = partyId.split('::')
 
@@ -438,10 +447,30 @@ export class WalletSyncService {
                 }
 
                 this.logger.info({ wallet }, 'Wallet sync result')
-                await this.store.addWallet(wallet)
-                return wallet
+
+                const existingWallet = existingWalletsByParty.get(
+                    `${partyId}:${networkId}`
+                )
+
+                if (existingWallet) {
+                    await this.store.updateWallet({
+                        partyId: wallet.partyId,
+                        networkId: wallet.networkId,
+                        signingProviderId: wallet.signingProviderId,
+                        publicKey: wallet.publicKey,
+                        disabled: wallet.disabled,
+                        reason: wallet.reason,
+                        rights: wallet.rights,
+                    })
+                    reEnabled.push(wallet)
+                } else {
+                    await this.store.addWallet(wallet)
+                    added.push(wallet)
+                }
             })
         )
+
+        return { added, reEnabled }
     }
 
     private async handleRightsUpdates(
@@ -488,15 +517,27 @@ export class WalletSyncService {
             const existingAllocatedWallets = existingWallets.filter(
                 (w) => w.status === 'allocated'
             )
-            const existingPartiesOnNetwork = new Set(
-                existingAllocatedWallets.map(
-                    (w) => `${w.partyId}:${w.networkId}`
-                )
+            const existingWalletsByParty = new Map(
+                existingAllocatedWallets.map((w) => [
+                    `${w.partyId}:${w.networkId}`,
+                    w,
+                ])
+            )
+            // Disabled wallets are treated as if they don't exist, so a
+            // party whose wallet got disabled (e.g. no signing provider
+            // matched at the time) is re-checked on every sync instead of
+            // staying disabled forever once its signing provider resolves.
+            const existingEnabledPartiesOnNetwork = new Set(
+                existingAllocatedWallets
+                    .filter((w) => !w.disabled)
+                    .map((w) => `${w.partyId}:${w.networkId}`)
             )
 
             const newParties = partiesWithRights.filter(
                 (party) =>
-                    !existingPartiesOnNetwork.has(`${party}:${network.id}`)
+                    !existingEnabledPartiesOnNetwork.has(
+                        `${party}:${network.id}`
+                    )
                 // todo: filter on idp id
             )
 
@@ -506,8 +547,12 @@ export class WalletSyncService {
                     new Set(partiesWithRights)
                 )
 
+            // Disabled wallets are handled by handlePartiesWithoutWallet below
+            // (which sets fresh rights as part of re-enabling them) -- updating
+            // their rights here too would report the same wallet in both the
+            // "updated" and "disabled" result buckets.
             const rightsUpdatedWallets = await this.handleRightsUpdates(
-                existingAllocatedWallets,
+                existingAllocatedWallets.filter((w) => !w.disabled),
                 rightsByParty
             )
 
@@ -522,11 +567,15 @@ export class WalletSyncService {
                 'Wallets without parties'
             )
 
-            const newParticipantWallets = await this.handlePartiesWithoutWallet(
+            const {
+                added: newParticipantWallets,
+                reEnabled: reEnabledWallets,
+            } = await this.handlePartiesWithoutWallet(
                 newParties,
                 network.id,
                 rightsByParty,
-                participantNamespace
+                participantNamespace,
+                existingWalletsByParty
             )
 
             // Set primary wallet if none exists, or if primary is on an initialized wallet
@@ -549,6 +598,7 @@ export class WalletSyncService {
             const updatedRaw = [
                 ...updatedToInitialized,
                 ...rightsUpdatedWallets,
+                ...reEnabledWallets,
             ]
 
             const added = newWallets.filter((wallet) => !wallet.disabled)


### PR DESCRIPTION
## Summary

- `syncWallets()` (`wallet-gateway/remote/src/ledger/wallet-sync-service.ts`) treated a disabled wallet as still "existing" when computing which parties on the ledger are new. A party whose wallet got disabled (e.g. no signing provider matched at the time) was therefore never re-checked on later syncs and stayed disabled forever, even once its signing provider became resolvable.
- Excluding disabled wallets from that check isn't enough by itself: `store.addWallet()` throws on a duplicate `(partyId, networkId)`. `handlePartiesWithoutWallet()` now looks up whether a wallet row already exists for the party and calls `updateWallet()` to re-enable it in place instead of `addWallet()`.
- Extended `UpdateWallet` (`core/wallet-store`, `core/wallet-store-sql`) with `signingProviderId`/`publicKey` so the freshly re-resolved signing provider can actually be persisted when a wallet is re-enabled (previously `updateWallet` only supported `disabled`/`reason`/`rights`/etc.).
- Also excluded disabled wallets from the separate rights-update pass (`handleRightsUpdates`), since `handlePartiesWithoutWallet` already sets fresh rights as part of re-enabling them — otherwise the same wallet could get reported in both the `updated` and `disabled` buckets of the sync result.

Fixes #2206

## Test plan

- [x] Added a regression test: a disabled wallet whose party regains a matching signing provider gets re-enabled via `updateWallet` (not a duplicate `addWallet` throw), and shows up in `result.updated`.
- [x] `npx vitest run --project node src/ledger/wallet-sync-service.test.ts` — 22/22 passing (one pre-existing, unrelated SQLite-migration failure in a different describe block was confirmed present on `main` too, before this change).
- [x] `npx vitest run` on `core/wallet-store-inmemory` — 21/21 passing.
- [x] `eslint` and `prettier --check` clean on all 4 changed files.
- [x] `tsc --noEmit` clean on `wallet-gateway/remote`, `core/wallet-store`, and `core/wallet-store-sql`.