### PR TITLE
fix: scope validation

### DIFF
--- a/wallet-gateway/remote/src/user-api/controller.test.ts
+++ b/wallet-gateway/remote/src/user-api/controller.test.ts
@@ -138,7 +138,7 @@ const storeNetwork: StoreNetwork = {
     auth: {
         method: 'authorization_code',
         clientId: 'cid',
-        scope: 'scope',
+        scope: 'scope1 scope2',
         audience: 'aud',
     },
     adminAuth: {
@@ -956,9 +956,9 @@ describe('userController', () => {
         const validAddSessionClaims = {
             iss: idp.issuer,
             aud: storeNetwork.auth.audience,
-            sub: storeNetwork.auth.clientId,
-            scope: 'scope',
-            scp: ['scope'],
+            sub: 'sub',
+            scope: 'scope1 scope2',
+            scp: ['scope1', 'scope2'],
             exp: 1_900_000_000,
             iat: 1_800_000_000,
         }
@@ -1206,7 +1206,7 @@ describe('userController', () => {
                 accessToken: createJwt({
                     iss: idp.issuer,
                     aud: storeNetwork.auth.audience,
-                    sub: storeNetwork.auth.clientId,
+                    sub: 'sub',
                     exp: 1_900_000_000,
                     iat: 1_800_000_000,
                 }),
@@ -1229,7 +1229,7 @@ describe('userController', () => {
             ).rejects.toThrow('Failed to add session')
         })
 
-        it('addSession passes when only scope is present and matches', async () => {
+        it('addSession passes when only scope is present and has all requested scopes', async () => {
             const authWithScopeOnly = createAuthWithAddSessionClaims({
                 scp: undefined,
             })
@@ -1260,7 +1260,7 @@ describe('userController', () => {
             expect(result.network).not.toHaveProperty('serviceAccountAuth')
         })
 
-        it('addSession rejects when only scope is present and mismatches', async () => {
+        it('addSession rejects when only scope is present and does not have requested claims', async () => {
             const authWithInvalidScope = createAuthWithAddSessionClaims({
                 scope: 'openid email',
                 scp: undefined,
@@ -1283,10 +1283,10 @@ describe('userController', () => {
             ).rejects.toThrow('Failed to add session')
         })
 
-        it('addSession rejects when both scope and scp are present but one mismatches', async () => {
+        it('addSession passes when scope matches and scp mismatches', async () => {
             const authWithMismatchedScp = createAuthWithAddSessionClaims({
-                scope: 'scope',
-                scp: ['scope openid'],
+                scope: 'scope1 scope2',
+                scp: ['scope3'],
             })
             const store = await createStore(logger, authWithMismatchedScp, {
                 withWallet: false,
@@ -1298,12 +1298,35 @@ describe('userController', () => {
                 authWithMismatchedScp
             )
 
-            await expect(
-                controller.addSession({
-                    origin: 'dapp-1',
-                    networkId: 'network1',
-                })
-            ).rejects.toThrow('Failed to add session')
+            const result = await controller.addSession({
+                origin: 'dapp-1',
+                networkId: 'network1',
+            })
+
+            expect(result.status).toBe('connected')
+        })
+
+        it('addSession passes when scope is a superset of network auth scope', async () => {
+            const authWithExtraScopes = createAuthWithAddSessionClaims({
+                scope: 'scope1 scope2 openid email',
+                scp: undefined,
+            })
+            const store = await createStore(logger, authWithExtraScopes, {
+                withWallet: false,
+            })
+            const controller = createController(
+                store,
+                notificationService,
+                logger,
+                authWithExtraScopes
+            )
+
+            const result = await controller.addSession({
+                origin: 'dapp-1',
+                networkId: 'network1',
+            })
+
+            expect(result.status).toBe('connected')
         })
 
         it('addSession rejects token with issuer mismatch', async () => {

--- a/wallet-gateway/remote/src/user-api/controller.test.ts
+++ b/wallet-gateway/remote/src/user-api/controller.test.ts
@@ -1329,6 +1329,98 @@ describe('userController', () => {
             expect(result.status).toBe('connected')
         })
 
+        it('addSession passes when only scp is present and has all requested scopes', async () => {
+            const authWithScpOnly = createAuthWithAddSessionClaims({
+                scope: undefined,
+                scp: ['scope1', 'scope2'],
+            })
+            const store = await createStore(logger, authWithScpOnly, {
+                withWallet: false,
+            })
+            const controller = createController(
+                store,
+                notificationService,
+                logger,
+                authWithScpOnly
+            )
+
+            const result = await controller.addSession({
+                origin: 'dapp-1',
+                networkId: 'network1',
+            })
+
+            expect(result.status).toBe('connected')
+        })
+
+        it('addSession passes when only scp is present and is a superset of network auth scope', async () => {
+            const authWithScpSuperset = createAuthWithAddSessionClaims({
+                scope: undefined,
+                scp: ['scope1', 'scope2', 'openid', 'email', 'daml_ledger_api'],
+            })
+            const store = await createStore(logger, authWithScpSuperset, {
+                withWallet: false,
+            })
+            const controller = createController(
+                store,
+                notificationService,
+                logger,
+                authWithScpSuperset
+            )
+
+            const result = await controller.addSession({
+                origin: 'dapp-1',
+                networkId: 'network1',
+            })
+
+            expect(result.status).toBe('connected')
+        })
+
+        it('addSession rejects when only scp is present and does not include all network auth scope values', async () => {
+            const authWithInvalidScp = createAuthWithAddSessionClaims({
+                scope: undefined,
+                scp: ['email', 'profile'],
+            })
+            const store = await createStore(logger, authWithInvalidScp, {
+                withWallet: false,
+            })
+            const controller = createController(
+                store,
+                notificationService,
+                logger,
+                authWithInvalidScp
+            )
+
+            await expect(
+                controller.addSession({
+                    origin: 'dapp-1',
+                    networkId: 'network1',
+                })
+            ).rejects.toThrow('Failed to add session')
+        })
+
+        it('addSession rejects when scope is incomplete even if scp has all requested scopes', async () => {
+            const authWithIncompleteScope = createAuthWithAddSessionClaims({
+                scope: 'scope1',
+                scp: ['scope1', 'scope2'],
+            })
+            const store = await createStore(logger, authWithIncompleteScope, {
+                withWallet: false,
+            })
+            const controller = createController(
+                store,
+                notificationService,
+                logger,
+                authWithIncompleteScope
+            )
+
+            await expect(
+                controller.addSession({
+                    origin: 'dapp-1',
+                    networkId: 'network1',
+                })
+            ).rejects.toThrow('Failed to add session')
+        })
+
         it('addSession rejects token with issuer mismatch', async () => {
             const authWithInvalidIssuer = createAuthWithAddSessionClaims({
                 iss: 'http://wrong-issuer',

--- a/wallet-gateway/remote/src/user-api/controller.test.ts
+++ b/wallet-gateway/remote/src/user-api/controller.test.ts
@@ -1200,102 +1200,19 @@ describe('userController', () => {
             })
         })
 
-        it('addSession rejects token when both scope and scp are missing', async () => {
-            const authWithoutScopeClaims: AuthContext = {
-                ...auth,
-                accessToken: createJwt({
-                    iss: idp.issuer,
-                    aud: storeNetwork.auth.audience,
-                    sub: 'sub',
-                    exp: 1_900_000_000,
-                    iat: 1_800_000_000,
-                }),
-            }
-            const store = await createStore(logger, authWithoutScopeClaims, {
-                withWallet: false,
-            })
-            const controller = createController(
-                store,
-                notificationService,
-                logger,
-                authWithoutScopeClaims
-            )
-
-            await expect(
-                controller.addSession({
-                    origin: 'dapp-1',
-                    networkId: 'network1',
-                })
-            ).rejects.toThrow('Failed to add session')
-        })
-
-        it('addSession passes when only scope is present and has all requested scopes', async () => {
-            const authWithScopeOnly = createAuthWithAddSessionClaims({
-                scp: undefined,
-            })
-            const store = await createStore(logger, authWithScopeOnly, {
-                withWallet: false,
-            })
-            const controller = createController(
-                store,
-                notificationService,
-                logger,
-                authWithScopeOnly
-            )
-
-            const result = await controller.addSession({
-                origin: 'dapp-1',
-                networkId: 'network1',
-            })
-            expect(result).toMatchObject({
-                network: expect.objectContaining({
-                    id: 'network1',
-                    auth: expect.objectContaining({
-                        method: 'authorization_code',
-                    }),
-                }),
-                status: 'connected',
-            })
-            expect(result.network).not.toHaveProperty('adminAuth')
-            expect(result.network).not.toHaveProperty('serviceAccountAuth')
-        })
-
-        it('addSession rejects when only scope is present and does not have requested claims', async () => {
-            const authWithInvalidScope = createAuthWithAddSessionClaims({
+        it('addSession does not validate scope or scp against network.auth.scope', async () => {
+            const authWithUnrelatedScopes = createAuthWithAddSessionClaims({
                 scope: 'openid email',
-                scp: undefined,
+                scp: ['profile'],
             })
-            const store = await createStore(logger, authWithInvalidScope, {
+            const store = await createStore(logger, authWithUnrelatedScopes, {
                 withWallet: false,
             })
             const controller = createController(
                 store,
                 notificationService,
                 logger,
-                authWithInvalidScope
-            )
-
-            await expect(
-                controller.addSession({
-                    origin: 'dapp-1',
-                    networkId: 'network1',
-                })
-            ).rejects.toThrow('Failed to add session')
-        })
-
-        it('addSession passes when scope matches and scp mismatches', async () => {
-            const authWithMismatchedScp = createAuthWithAddSessionClaims({
-                scope: 'scope1 scope2',
-                scp: ['scope3'],
-            })
-            const store = await createStore(logger, authWithMismatchedScp, {
-                withWallet: false,
-            })
-            const controller = createController(
-                store,
-                notificationService,
-                logger,
-                authWithMismatchedScp
+                authWithUnrelatedScopes
             )
 
             const result = await controller.addSession({
@@ -1304,121 +1221,6 @@ describe('userController', () => {
             })
 
             expect(result.status).toBe('connected')
-        })
-
-        it('addSession passes when scope is a superset of network auth scope', async () => {
-            const authWithExtraScopes = createAuthWithAddSessionClaims({
-                scope: 'scope1 scope2 openid email',
-                scp: undefined,
-            })
-            const store = await createStore(logger, authWithExtraScopes, {
-                withWallet: false,
-            })
-            const controller = createController(
-                store,
-                notificationService,
-                logger,
-                authWithExtraScopes
-            )
-
-            const result = await controller.addSession({
-                origin: 'dapp-1',
-                networkId: 'network1',
-            })
-
-            expect(result.status).toBe('connected')
-        })
-
-        it('addSession passes when only scp is present and has all requested scopes', async () => {
-            const authWithScpOnly = createAuthWithAddSessionClaims({
-                scope: undefined,
-                scp: ['scope1', 'scope2'],
-            })
-            const store = await createStore(logger, authWithScpOnly, {
-                withWallet: false,
-            })
-            const controller = createController(
-                store,
-                notificationService,
-                logger,
-                authWithScpOnly
-            )
-
-            const result = await controller.addSession({
-                origin: 'dapp-1',
-                networkId: 'network1',
-            })
-
-            expect(result.status).toBe('connected')
-        })
-
-        it('addSession passes when only scp is present and is a superset of network auth scope', async () => {
-            const authWithScpSuperset = createAuthWithAddSessionClaims({
-                scope: undefined,
-                scp: ['scope1', 'scope2', 'openid', 'email', 'daml_ledger_api'],
-            })
-            const store = await createStore(logger, authWithScpSuperset, {
-                withWallet: false,
-            })
-            const controller = createController(
-                store,
-                notificationService,
-                logger,
-                authWithScpSuperset
-            )
-
-            const result = await controller.addSession({
-                origin: 'dapp-1',
-                networkId: 'network1',
-            })
-
-            expect(result.status).toBe('connected')
-        })
-
-        it('addSession rejects when only scp is present and does not include all network auth scope values', async () => {
-            const authWithInvalidScp = createAuthWithAddSessionClaims({
-                scope: undefined,
-                scp: ['email', 'profile'],
-            })
-            const store = await createStore(logger, authWithInvalidScp, {
-                withWallet: false,
-            })
-            const controller = createController(
-                store,
-                notificationService,
-                logger,
-                authWithInvalidScp
-            )
-
-            await expect(
-                controller.addSession({
-                    origin: 'dapp-1',
-                    networkId: 'network1',
-                })
-            ).rejects.toThrow('Failed to add session')
-        })
-
-        it('addSession rejects when scope is incomplete even if scp has all requested scopes', async () => {
-            const authWithIncompleteScope = createAuthWithAddSessionClaims({
-                scope: 'scope1',
-                scp: ['scope1', 'scope2'],
-            })
-            const store = await createStore(logger, authWithIncompleteScope, {
-                withWallet: false,
-            })
-            const controller = createController(
-                store,
-                notificationService,
-                logger,
-                authWithIncompleteScope
-            )
-
-            await expect(
-                controller.addSession({
-                    origin: 'dapp-1',
-                    networkId: 'network1',
-                })
-            ).rejects.toThrow('Failed to add session')
         })
 
         it('addSession rejects token with issuer mismatch', async () => {

--- a/wallet-gateway/remote/src/user-api/token-network-matching.ts
+++ b/wallet-gateway/remote/src/user-api/token-network-matching.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Idp, Auth } from '@canton-network/core-wallet-auth'
+import { Idp } from '@canton-network/core-wallet-auth'
 import { Network } from '@canton-network/core-wallet-store'
 import { decodeJwt, JWTPayload } from 'jose'
 
@@ -15,31 +15,6 @@ function normalizeAudienceClaim(value: JWTPayload['aud']): string[] {
     }
 
     return []
-}
-
-function normalizeScopeClaim(
-    value: JWTPayload['scope'] | JWTPayload['scp'] | Auth['scope']
-): string[] {
-    if (typeof value === 'string') {
-        return value.split(/\s+/)
-    }
-
-    if (Array.isArray(value)) {
-        return value
-    }
-
-    return []
-}
-
-function claimContainsRequestedScopes(
-    tokenClaim: unknown,
-    networkAuthScopes: string[]
-): boolean {
-    const claimScopes = normalizeScopeClaim(tokenClaim)
-    // token claim scopes has same scopes as requested - pass
-    // token claim scopes is superset of requested scopes - pass
-    // token claim doesn't have requested scopes - fail
-    return networkAuthScopes.every((scope) => claimScopes.includes(scope))
 }
 
 export function assertTokenClaimsMatchNetwork(
@@ -67,28 +42,5 @@ export function assertTokenClaimsMatchNetwork(
         throw new Error(
             `Token client ID doesn't match network's auth clientId.`
         )
-    }
-
-    const requestedScopes = normalizeScopeClaim(network.auth.scope)
-    const hasScopeClaim = tokenClaims.scope !== undefined
-    const hasScpClaim = tokenClaims.scp !== undefined
-
-    if (!hasScopeClaim && !hasScpClaim) {
-        throw new Error(`Token scope and scp claims missing.`)
-    }
-
-    // Prefer scope claim. Test scp instead if scope is not present.
-    if (hasScopeClaim) {
-        if (!claimContainsRequestedScopes(tokenClaims.scope, requestedScopes)) {
-            throw new Error(
-                `Token scope claim doesn't match network's auth scope.`
-            )
-        }
-
-        return
-    }
-
-    if (!claimContainsRequestedScopes(tokenClaims.scp, requestedScopes)) {
-        throw new Error(`Token scp claim doesn't match network's auth scope.`)
     }
 }

--- a/wallet-gateway/remote/src/user-api/token-network-matching.ts
+++ b/wallet-gateway/remote/src/user-api/token-network-matching.ts
@@ -31,15 +31,15 @@ function normalizeScopeClaim(
     return []
 }
 
-function claimContainsRequiredScopes(
+function claimContainsRequestedScopes(
     tokenClaim: unknown,
     networkAuthScopes: string[]
 ): boolean {
     const claimScopes = normalizeScopeClaim(tokenClaim)
-    return (
-        claimScopes.length === networkAuthScopes.length &&
-        networkAuthScopes.every((scope) => claimScopes.includes(scope))
-    )
+    // token claim scopes has same scopes as requested - pass
+    // token claim scopes is superset of requested scopes - pass
+    // token claim doesn't have requested scopes - fail
+    return networkAuthScopes.every((scope) => claimScopes.includes(scope))
 }
 
 export function assertTokenClaimsMatchNetwork(
@@ -69,7 +69,7 @@ export function assertTokenClaimsMatchNetwork(
         )
     }
 
-    const requiredScopes = normalizeScopeClaim(network.auth.scope)
+    const requestedScopes = normalizeScopeClaim(network.auth.scope)
     const hasScopeClaim = tokenClaims.scope !== undefined
     const hasScpClaim = tokenClaims.scp !== undefined
 
@@ -77,17 +77,18 @@ export function assertTokenClaimsMatchNetwork(
         throw new Error(`Token scope and scp claims missing.`)
     }
 
-    if (
-        hasScopeClaim &&
-        !claimContainsRequiredScopes(tokenClaims.scope, requiredScopes)
-    ) {
-        throw new Error(`Token scope claim doesn't match network's auth scope.`)
+    // Prefer scope claim. Test scp instead if scope is not present.
+    if (hasScopeClaim) {
+        if (!claimContainsRequestedScopes(tokenClaims.scope, requestedScopes)) {
+            throw new Error(
+                `Token scope claim doesn't match network's auth scope.`
+            )
+        }
+
+        return
     }
 
-    if (
-        hasScpClaim &&
-        !claimContainsRequiredScopes(tokenClaims.scp, requiredScopes)
-    ) {
+    if (!claimContainsRequestedScopes(tokenClaims.scp, requestedScopes)) {
         throw new Error(`Token scp claim doesn't match network's auth scope.`)
     }
 }


### PR DESCRIPTION
Removed validation of `accessToken.scope` and/or `accessToken.scp` against `network.auth.scope` in `userApi.addSession`.
As OIDC standard permits auth server to return token with different `scope`/`scp` claims than requested, it is not possible to reliably validate them against `network.auth.scope`. `iss` and `aud` claims comparison against `network.auth` remain main mechanism for ensuring token is meant for a specific network when calling `addSession`. 