### PR TITLE
fix(wallet-gateway-remote): show OAuth callback errors

### DIFF
--- a/wallet-gateway/remote/src/web/frontend/callback/index.test.ts
+++ b/wallet-gateway/remote/src/web/frontend/callback/index.test.ts
@@ -11,12 +11,14 @@ const {
     mockAccessTokenSet,
     mockExpirationDateSet,
     mockNetworkIdGet,
+    mockHandleErrorToast,
 } = vi.hoisted(() => ({
     mockRedirectToIntendedOrDefault: vi.fn(),
     mockAddUserSession: vi.fn().mockResolvedValue(undefined),
     mockAccessTokenSet: vi.fn(),
     mockExpirationDateSet: vi.fn(),
     mockNetworkIdGet: vi.fn(() => 'net-1'),
+    mockHandleErrorToast: vi.fn(),
 }))
 
 vi.mock('../index.js', () => ({
@@ -31,6 +33,13 @@ vi.mock('../state-manager.js', () => ({
         currentOrigin: { get: vi.fn(), set: vi.fn(), clear: vi.fn() },
     },
 }))
+vi.mock('@canton-network/core-wallet-ui-components', async (importOriginal) => {
+    const actual =
+        await importOriginal<
+            typeof import('@canton-network/core-wallet-ui-components')
+        >()
+    return { ...actual, handleErrorToast: mockHandleErrorToast }
+})
 
 import './index.js'
 import { LoginCallback } from './index.js'
@@ -91,16 +100,38 @@ function expectNoAuthSideEffects() {
     expect(mockRedirectToIntendedOrDefault).not.toHaveBeenCalled()
 }
 
+async function expectRecoverableError(el: LoginCallback) {
+    await waitUntil(() => mockHandleErrorToast.mock.calls.length > 0)
+    await el.updateComplete
+
+    expect(el.shadowRoot?.querySelector('wg-loading-state')).toBeNull()
+
+    const errorPage = el.shadowRoot?.querySelector('wg-error-page') as
+        | (HTMLElement & {
+              title: string
+              message: string
+              backHref: string
+          })
+        | null
+
+    expect(errorPage?.title).toBe('Login failed')
+    expect(errorPage?.message).toBe(
+        'We could not complete your login. Return to network selection and try again.'
+    )
+    expect(errorPage?.backHref).toBe('/login')
+}
+
 describe('LoginCallback', () => {
     let el: LoginCallback
     const componentFixture = html`<login-callback></login-callback>`
 
     beforeEach(() => {
         mockRedirectToIntendedOrDefault.mockReset()
-        mockAddUserSession.mockClear()
+        mockAddUserSession.mockReset().mockResolvedValue(undefined)
         mockAccessTokenSet.mockReset()
         mockExpirationDateSet.mockReset()
         mockNetworkIdGet.mockReturnValue('net-1')
+        mockHandleErrorToast.mockReset()
         sessionStorage.clear()
         setCallbackUrl()
     })
@@ -113,6 +144,13 @@ describe('LoginCallback', () => {
     })
 
     it('renders the loading state', async () => {
+        setCallbackUrl('auth-code', oauthState)
+        sessionStorage.setItem('oauth-pkce-state-123', 'pkce-verifier')
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(() => new Promise<Response>(() => {}))
+        )
+
         el = await fixture<LoginCallback>(componentFixture)
 
         const loadingState = el.shadowRoot?.querySelector(
@@ -123,35 +161,39 @@ describe('LoginCallback', () => {
         expect(loadingState?.text).toBe('Logging in...')
     })
 
-    it('does nothing when both code and state are missing', async () => {
+    it('shows a recoverable error when both code and state are missing', async () => {
         el = await fixture<LoginCallback>(componentFixture)
 
         expectNoAuthSideEffects()
+        await expectRecoverableError(el)
     })
 
-    it('does nothing when only the authorization code is present', async () => {
+    it('shows a recoverable error when only the authorization code is present', async () => {
         setCallbackUrl('auth-code-only')
         el = await fixture<LoginCallback>(componentFixture)
 
         expectNoAuthSideEffects()
+        await expectRecoverableError(el)
     })
 
-    it('does nothing when only the state parameter is present', async () => {
+    it('shows a recoverable error when only the state parameter is present', async () => {
         setCallbackUrl(undefined, oauthState)
         el = await fixture<LoginCallback>(componentFixture)
 
         expectNoAuthSideEffects()
+        await expectRecoverableError(el)
     })
 
-    it('does nothing when the PKCE verifier is missing from session storage', async () => {
+    it('shows a recoverable error when the PKCE verifier is missing', async () => {
         setCallbackUrl('auth-code', oauthState)
         stubOAuthFetch(tokenWithExpiry())
         el = await fixture<LoginCallback>(componentFixture)
 
         expectNoAuthSideEffects()
+        await expectRecoverableError(el)
     })
 
-    it('does nothing when the token endpoint returns no access_token', async () => {
+    it('shows a recoverable error when the token endpoint returns no access token', async () => {
         setCallbackUrl('auth-code', oauthState)
         sessionStorage.setItem('oauth-pkce-state-123', 'pkce-verifier')
         stubOAuthFetch()
@@ -165,6 +207,7 @@ describe('LoginCallback', () => {
         )
 
         expectNoAuthSideEffects()
+        await expectRecoverableError(el)
     })
 
     it('uses an empty network id when none is stored in state', async () => {
@@ -203,5 +246,19 @@ describe('LoginCallback', () => {
         await waitUntil(
             () => mockRedirectToIntendedOrDefault.mock.calls.length > 0
         )
+    })
+
+    it('shows a recoverable error when adding the user session fails', async () => {
+        const error = new Error('addSession failed')
+        mockAddUserSession.mockRejectedValueOnce(error)
+        setCallbackUrl('auth-code', oauthState)
+        sessionStorage.setItem('oauth-pkce-state-123', 'pkce-verifier')
+        stubOAuthFetch(tokenWithExpiry())
+
+        el = await fixture<LoginCallback>(componentFixture)
+
+        await expectRecoverableError(el)
+        expect(mockHandleErrorToast).toHaveBeenCalledWith(error)
+        expect(mockRedirectToIntendedOrDefault).not.toHaveBeenCalled()
     })
 })

--- a/wallet-gateway/remote/src/web/frontend/callback/index.ts
+++ b/wallet-gateway/remote/src/web/frontend/callback/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { LitElement, html } from 'lit'
-import { customElement } from 'lit/decorators.js'
+import { customElement, state } from 'lit/decorators.js'
 import { stateManager } from '../state-manager'
 import { addUserSession, redirectToIntendedOrDefault } from '..'
 import {
@@ -10,33 +10,36 @@ import {
     toRelHref,
 } from '@canton-network/core-wallet-ui-components'
 import { detectCurrentOrigin } from '../listeners'
+import { LOGIN_PAGE_REDIRECT } from '../constants'
 
 @customElement('login-callback')
 export class LoginCallback extends LitElement {
+    @state() accessor hasError = false
+
     connectedCallback(): void {
         super.connectedCallback()
-        this.handleRedirect()
+        void this.handleRedirect()
     }
 
     async handleRedirect() {
-        const url = new URL(window.location.href)
-        const code = url.searchParams.get('code')
-        const encodedState = url.searchParams.get('state')
+        try {
+            const url = new URL(window.location.href)
+            const code = url.searchParams.get('code')
+            const encodedState = url.searchParams.get('state')
 
-        if (!code && !encodedState) {
-            console.error('missing state and code')
-            return
-        }
+            if (!code || !encodedState) {
+                throw new Error('Missing state or code in OAuth callback')
+            }
 
-        if (code && encodedState) {
             const state = JSON.parse(atob(encodedState))
             const pkceVerifier = sessionStorage.getItem(
                 `oauth-pkce-${state.stateId}`
             )
 
             if (!pkceVerifier) {
-                console.error('missing PKCE verifier for OAuth callback state')
-                return
+                throw new Error(
+                    'Missing PKCE verifier for OAuth callback state'
+                )
             }
 
             sessionStorage.removeItem(`oauth-pkce-${state.stateId}`)
@@ -65,35 +68,45 @@ export class LoginCallback extends LitElement {
             })
 
             const tokenResponse = await res.json()
+            if (!tokenResponse.access_token) {
+                throw new Error('OAuth token response has no access token')
+            }
+
             const currentOrigin = await detectCurrentOrigin()
 
-            if (tokenResponse.access_token) {
-                const payload = JSON.parse(
-                    atob(tokenResponse.access_token.split('.')[1])
-                )
-                stateManager.expirationDate.set(
-                    new Date(payload.exp * 1000).toISOString(),
-                    currentOrigin
-                )
+            const payload = JSON.parse(
+                atob(tokenResponse.access_token.split('.')[1])
+            )
+            stateManager.expirationDate.set(
+                new Date(payload.exp * 1000).toISOString(),
+                currentOrigin
+            )
 
-                await stateManager.accessToken.set(
-                    tokenResponse.access_token,
-                    currentOrigin
-                )
+            await stateManager.accessToken.set(
+                tokenResponse.access_token,
+                currentOrigin
+            )
 
-                addUserSession(
-                    tokenResponse.access_token,
-                    stateManager.networkId.get(currentOrigin) || ''
-                )
-                    .then(() => {
-                        redirectToIntendedOrDefault()
-                    })
-                    .catch(handleErrorToast)
-            }
+            await addUserSession(
+                tokenResponse.access_token,
+                stateManager.networkId.get(currentOrigin) || ''
+            )
+            await redirectToIntendedOrDefault()
+        } catch (error) {
+            this.hasError = true
+            handleErrorToast(error)
         }
     }
 
     render() {
+        if (this.hasError) {
+            return html`<wg-error-page
+                title="Login failed"
+                message="We could not complete your login. Return to network selection and try again."
+                .backHref=${LOGIN_PAGE_REDIRECT}
+            ></wg-error-page>`
+        }
+
         return html`<wg-loading-state
             .text=${'Logging in...'}
         ></wg-loading-state>`


### PR DESCRIPTION
## Summary

- replace the indefinitely loading OAuth callback state with a recoverable error page when callback data, the PKCE verifier, or the access token is missing
- handle asynchronous session creation failures through the same error state while preserving the detailed error toast
- provide a route back to network selection and add browser coverage for each failure path

## Testing

- `pnpm --filter @canton-network/wallet-gateway-remote test` (43 files, 451 tests)
- `pnpm exec nx run @canton-network/wallet-gateway-remote:lint --skip-nx-cache`
- `pnpm --filter @canton-network/wallet-gateway-remote build`

Closes #2348

AI assistance disclosure: This contribution was prepared with OpenAI Codex assistance. The contributor reviewed the implementation, tests, and verification results.