### PR TITLE
perf(example-portfolio): speed up the portfolio e2e job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
                       core/**/dist/
                       sdk/**/dist/
                       wallet-gateway/**/dist/
+                      examples/portfolio/dist/
                       damljs
                       .nx/cache
                       .nx/workspace-data

--- a/core/wallet-test-utils/package.json
+++ b/core/wallet-test-utils/package.json
@@ -16,7 +16,11 @@
         }
     },
     "dependencies": {
+        "@canton-network/core-ledger-client": "workspace:^",
+        "@canton-network/core-rpc-transport": "workspace:^",
         "@canton-network/core-types": "workspace:^",
+        "@canton-network/core-wallet-auth": "workspace:^",
+        "@canton-network/core-wallet-user-rpc-client": "workspace:^",
         "@canton-network/wallet-sdk": "workspace:^",
         "@playwright/test": "^1.61.1",
         "pino": "^10.3.1",

--- a/core/wallet-test-utils/src/gateway-user-api.ts
+++ b/core/wallet-test-utils/src/gateway-user-api.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { HttpTransport } from '@canton-network/core-rpc-transport'
+import UserApiClient from '@canton-network/core-wallet-user-rpc-client'
+
+/**
+ * Client for the wallet gateway User API.
+ *
+ * Lets a test create wallets by calling the wallet directly, instead of driving
+ * its web UI with Playwright. These are the same JSON-RPC methods that UI calls
+ * under the hood, and going through it reloads a page per call (~1.5s).
+ *
+ * Auth (self-signed networks like LocalNet): ask the gateway for a token, then
+ * open a session with it. Neither call needs an existing session.
+ */
+
+/** Signing providers the gateway can allocate a wallet with. */
+export type GatewaySigningProvider =
+    'participant' | 'wallet-kernel' | 'blockdaemon' | 'dfns' | 'fireblocks'
+
+export interface GatewayUserApiOptions {
+    /** Gateway origin, e.g. http://localhost:3030 */
+    baseUrl: string
+    /** Network id as bootstrapped in the gateway config, e.g. canton:localnet */
+    networkId: string
+    /**
+     * Client id to mint the token for. Becomes the JWT `sub`, which the gateway
+     * uses as the user id. Must match the client id the dApp connects with, or
+     * they end up as different users and the dApp sees no wallets.
+     */
+    clientId: string
+    /**
+     * Origin to record on the session. Must NOT be the dApp origin: the gateway
+     * keeps one session per (user, origin) and a new one replaces the old, so
+     * the dApp's connect would kill this session and every later call gets 401.
+     */
+    origin: string
+}
+
+/** Matches the shape HttpTransport throws when the gateway answers 401. */
+const isUnauthorized = (error: unknown): boolean =>
+    typeof error === 'object' &&
+    error !== null &&
+    'error' in error &&
+    (error as { error?: { code?: number } }).error?.code === 401
+
+export class GatewayUserApi {
+    private readonly url: URL
+    private readonly options: GatewayUserApiOptions
+    private client: UserApiClient
+
+    constructor(options: GatewayUserApiOptions) {
+        this.options = options
+        this.url = new URL(`${options.baseUrl}/api/v0/user`)
+        this.client = new UserApiClient(new HttpTransport(this.url))
+    }
+
+    /** Get a token and open a session. Calling it again replaces both. */
+    async connect(): Promise<void> {
+        const { accessToken } = await new UserApiClient(
+            new HttpTransport(this.url)
+        ).request({
+            method: 'selfSignedAccessToken',
+            params: {
+                networkId: this.options.networkId,
+                clientId: this.options.clientId,
+            },
+        })
+
+        this.client = new UserApiClient(
+            new HttpTransport(this.url, accessToken)
+        )
+
+        await this.client.request({
+            method: 'addSession',
+            params: {
+                networkId: this.options.networkId,
+                origin: this.options.origin,
+            },
+        })
+    }
+
+    /**
+     * Create a wallet and return its party id.
+     *
+     * Does not check whether the wallet already exists, unlike the UI helper.
+     * Tests use a random hint per run, so the check would be a wasted request.
+     */
+    async createWallet(args: {
+        partyHint: string
+        signingProvider: GatewaySigningProvider
+        primary?: boolean
+    }): Promise<string> {
+        const { wallet } = await this.withSession((client) =>
+            client.request({
+                method: 'createWallet',
+                params: {
+                    partyHint: args.partyHint,
+                    signingProviderId: args.signingProvider,
+                    primary: args.primary ?? false,
+                },
+            })
+        )
+        return wallet.partyId
+    }
+
+    /**
+     * Set the primary wallet. The gateway emits `accountsChanged` to the dApp,
+     * same as when a user does it in the wallet UI, so an open dApp picks it up.
+     */
+    async setPrimaryWallet(partyId: string): Promise<void> {
+        await this.withSession((client) =>
+            client.request({ method: 'setPrimaryWallet', params: { partyId } })
+        )
+    }
+
+    /**
+     * Run a call, and on 401 open a new session and try once more: another
+     * client of the same gateway user may have replaced our session.
+     */
+    private async withSession<T>(
+        call: (client: UserApiClient) => Promise<T>
+    ): Promise<T> {
+        try {
+            return await call(this.client)
+        } catch (error) {
+            if (!isUnauthorized(error)) throw error
+            await this.connect()
+            return call(this.client)
+        }
+    }
+}

--- a/core/wallet-test-utils/src/index.ts
+++ b/core/wallet-test-utils/src/index.ts
@@ -3,6 +3,7 @@
 
 export { OTCTrade } from './otc-trade.js'
 export * from './wallet-gateway.js'
+export * from './gateway-user-api.js'
 export * from './ledger-users.js'
 export { test, expect } from './fixtures.js'
 export * from './signing-provider-mocks/index.js'

--- a/core/wallet-test-utils/src/index.ts
+++ b/core/wallet-test-utils/src/index.ts
@@ -3,5 +3,6 @@
 
 export { OTCTrade } from './otc-trade.js'
 export * from './wallet-gateway.js'
+export * from './ledger-users.js'
 export { test, expect } from './fixtures.js'
 export * from './signing-provider-mocks/index.js'

--- a/core/wallet-test-utils/src/ledger-users.ts
+++ b/core/wallet-test-utils/src/ledger-users.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { LedgerClient } from '@canton-network/core-ledger-client'
+import { AuthTokenProvider } from '@canton-network/core-wallet-auth'
+import { HttpTransport } from '@canton-network/core-rpc-transport'
+import UserApiClient from '@canton-network/core-wallet-user-rpc-client'
+import { pino } from 'pino'
+
+/**
+ * Creates ledger users on the participant.
+ *
+ * Needed when tests connect to the gateway with a client id other than the one
+ * in its network config (for example one user per Playwright worker).
+ *
+ * Why: the gateway accepts any JWT `sub` and just scopes wallets under it, but
+ * it forwards that same token to the participant, and Canton answers
+ * USER_NOT_FOUND if no user with that id exists there.
+ */
+
+export interface EnsureLedgerUsersOptions {
+    /** Gateway origin, e.g. http://localhost:3030 */
+    gatewayUrl: string
+    /** Participant ledger API, e.g. http://localhost:2975 */
+    ledgerApiUrl: string
+    /** Network id in the gateway, e.g. canton:localnet */
+    networkId: string
+    /**
+     * Client id from the gateway's config for that network. A user with this id
+     * exists on the participant, which is why it can mint the admin token.
+     */
+    adminClientId: string
+    /** User ids to create. Existing ones are skipped. */
+    userIds: string[]
+}
+
+/**
+ * Create each user on the participant, skipping the ones that exist.
+ *
+ * The admin token comes from the gateway instead of being signed here, so tests
+ * do not need the network's signing secret.
+ */
+export async function ensureLedgerUsers(
+    options: EnsureLedgerUsersOptions
+): Promise<void> {
+    if (options.userIds.length === 0) return
+
+    const logger = pino({ name: 'ensure-ledger-users', level: 'silent' })
+
+    const { accessToken } = await new UserApiClient(
+        new HttpTransport(new URL(`${options.gatewayUrl}/api/v0/user`))
+    ).request({
+        method: 'selfSignedAccessToken',
+        params: {
+            networkId: options.networkId,
+            clientId: options.adminClientId,
+        },
+    })
+
+    const ledger = new LedgerClient({
+        baseUrl: new URL(options.ledgerApiUrl),
+        logger,
+        accessTokenProvider: AuthTokenProvider.fromToken(accessToken, logger),
+    })
+
+    for (const userId of options.userIds) {
+        // No primary party: these users only need to exist so the participant
+        // accepts their tokens. createUser is a no-op if the user is there.
+        await ledger.createUser(userId, '')
+    }
+}

--- a/core/wallet-test-utils/src/wallet-gateway.ts
+++ b/core/wallet-test-utils/src/wallet-gateway.ts
@@ -105,6 +105,16 @@ export class WalletGateway {
     async connect(args: {
         network: string
         customURL?: string
+        /**
+         * Client id to log in with, instead of the one in the gateway's config
+         * for this network.
+         *
+         * On self-signed networks this becomes the JWT `sub`, which the gateway
+         * uses as the user id. Wallets and the primary wallet are per user, so
+         * passing one value per Playwright worker lets workers share a gateway
+         * without fighting over which wallet is primary.
+         */
+        clientId?: string
     }): Promise<void> {
         await test.step(`wallet gateway: connect to ${args.network}`, async () => {
             const dapp = this.requireDapp()
@@ -127,6 +137,13 @@ export class WalletGateway {
                 'the wallet gateway has a network select'
             ).toBeVisible()
             await selectNetwork.selectOption({ label: args.network })
+
+            if (args.clientId !== undefined) {
+                // Only rendered on self-signed networks. Prefilled with the
+                // network's client id.
+                await popup.locator('#client-id').fill(args.clientId)
+            }
+
             const confirmConnectButton = popup.getByRole('button', {
                 name: 'Connect',
             })

--- a/ecosystem.ci.config.js
+++ b/ecosystem.ci.config.js
@@ -23,8 +23,12 @@ export const apps = [
         env_development: sharedEnvDevelopment,
     },
     {
+        // Serves the production build, not the Vite dev server. In dev the
+        // browser loads hundreds of unbundled modules that Vite transforms on
+        // demand, which slows down every page the e2e tests open (~19% of the
+        // suite). The build comes from the CI build job.
         name: 'example-portfolio',
-        script: 'pnpm --filter @canton-network/example-portfolio dev',
+        script: 'pnpm --filter @canton-network/example-portfolio preview',
         env_development: sharedEnvDevelopment,
     },
 ]

--- a/examples/portfolio/playwright.config.ts
+++ b/examples/portfolio/playwright.config.ts
@@ -19,14 +19,28 @@ export default defineConfig({
         timeout: 15_000,
     },
     testDir: './tests',
+    /* Funds the validator and creates the per-worker ledger users. Runs once. */
+    globalSetup: './tests/global-setup.ts',
     /* Run tests in files in parallel */
     fullyParallel: false,
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */
     retries: process.env.CI ? 2 : 0,
-    /* Opt out of parallel tests on CI. */
-    workers: 1,
+    /*
+     * One spec file per worker (fullyParallel is false above).
+     *
+     * These tests mostly wait on the ledger instead of using CPU, so a couple
+     * running at once costs almost no extra CPU.
+     *
+     * Do not raise this without measuring. At 4 workers Canton alone takes 3
+     * cores and ledger waits double, which makes the run slower and flakier
+     * than at 2, and CI runners have 4 cores in total. PW_WORKERS overrides it.
+     *
+     * Only safe because each worker connects to the gateway as its own user and
+     * so does not share a primary wallet. See tests/utils.ts.
+     */
+    workers: Number(process.env.PW_WORKERS ?? 2),
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/examples/portfolio/tests/allocation.spec.ts
+++ b/examples/portfolio/tests/allocation.spec.ts
@@ -5,6 +5,7 @@ import { pino } from 'pino'
 import { expect, type Page, test } from '@playwright/test'
 import { OTCTrade } from '@canton-network/core-wallet-test-utils'
 import {
+    connectGateway,
     createWalletGateway,
     gotoConnect,
     setupRegistry,
@@ -69,7 +70,7 @@ const setupOtcTrade = async (page: Page) => {
     const wg = createWalletGateway(page)
 
     await gotoConnect(page)
-    await wg.connect({ network: 'LocalNet' })
+    await connectGateway(wg)
 
     const venueHint = `venue-${rnd}`
     const aliceHint = `alice-${rnd}`

--- a/examples/portfolio/tests/allocation.spec.ts
+++ b/examples/portfolio/tests/allocation.spec.ts
@@ -5,6 +5,7 @@ import { pino } from 'pino'
 import { expect, type Page, test } from '@playwright/test'
 import { OTCTrade } from '@canton-network/core-wallet-test-utils'
 import {
+    createGatewayApi,
     connectGateway,
     createWalletGateway,
     gotoConnect,
@@ -69,31 +70,34 @@ const setupOtcTrade = async (page: Page) => {
     const rnd = Math.floor(Math.random() * 100000)
     const wg = createWalletGateway(page)
 
-    await gotoConnect(page)
-    await connectGateway(wg)
-
     const venueHint = `venue-${rnd}`
     const aliceHint = `alice-${rnd}`
     const bobHint = `bob-${rnd}`
     const charlieHint = `charlie-${rnd}`
-    const venue = await wg.createWalletIfNotExists({
+
+    // Scaffolding: an OTC trade needs four parties and none of them is what
+    // this test asserts, so they are created through the wallet's API.
+    const api = await createGatewayApi()
+    const venue = await api.createWallet({
         partyHint: venueHint,
         signingProvider: 'participant',
     })
-    const alice = await wg.createWalletIfNotExists({
+    const alice = await api.createWallet({
         partyHint: aliceHint,
         signingProvider: 'participant',
+        primary: true,
     })
-    const bob = await wg.createWalletIfNotExists({
+    const bob = await api.createWallet({
         partyHint: bobHint,
         signingProvider: 'participant',
     })
-    const charlie = await wg.createWalletIfNotExists({
+    const charlie = await api.createWallet({
         partyHint: charlieHint,
         signingProvider: 'participant',
     })
 
-    await wg.setPrimaryWallet(alice)
+    await gotoConnect(page)
+    await connectGateway(wg)
     await setupRegistry(page)
 
     const logger = pino({ name: 'otc-trade', level: 'info' })
@@ -108,6 +112,7 @@ const setupOtcTrade = async (page: Page) => {
 
     return {
         wg,
+        api,
         otcTrade,
         otcTradeDetails,
         alice,
@@ -128,6 +133,7 @@ test.describe('OTC allocations', () => {
     }) => {
         const {
             wg,
+            api,
             otcTrade,
             otcTradeDetails,
             alice,
@@ -140,10 +146,10 @@ test.describe('OTC allocations', () => {
 
         await tapAndCreateAllocation(dappPage, wg, '1000', 2)
 
-        await switchWallet(dappPage, wg, bob)
+        await switchWallet(api, bob)
         await tapAndCreateAllocation(dappPage, wg, '1000')
 
-        await switchWallet(dappPage, wg, charlie)
+        await switchWallet(api, charlie)
         await tapAndCreateAllocation(dappPage, wg, '1000')
 
         await otcTrade.settle(otcTradeDetails)

--- a/examples/portfolio/tests/global-setup.ts
+++ b/examples/portfolio/tests/global-setup.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FullConfig } from '@playwright/test'
+import { ensureLedgerUsers } from '@canton-network/core-wallet-test-utils'
+import { fundValidatorOperator } from './fund-validator'
+import {
+    GATEWAY_URL,
+    LOCALNET_CLIENT_ID,
+    LOCALNET_LEDGER_API_URL,
+    LOCALNET_NETWORK_ID,
+    gatewayUserForWorker,
+} from './utils'
+
+/**
+ * Runs once before any worker starts. Two things the suite needs:
+ *
+ * 1. Amulet in the validator operator's wallet. It pays the fee when accepting
+ *    a preapproval proposal, and a fresh LocalNet gives it none, so proposals
+ *    would never be accepted.
+ *
+ * 2. A ledger user per worker. Workers connect to the gateway as their own user
+ *    to avoid fighting over the primary wallet, and Canton rejects tokens whose
+ *    subject does not exist on the participant.
+ *
+ * Both belong here rather than in a `beforeAll` so they happen exactly once,
+ * whatever the worker count.
+ */
+export default async function globalSetup(config: FullConfig): Promise<void> {
+    await fundValidatorOperator()
+
+    const workerUsers = Array.from({ length: config.workers }, (_, index) =>
+        gatewayUserForWorker(index)
+    ).filter((userId) => userId !== LOCALNET_CLIENT_ID)
+
+    await ensureLedgerUsers({
+        gatewayUrl: GATEWAY_URL,
+        ledgerApiUrl: LOCALNET_LEDGER_API_URL,
+        networkId: LOCALNET_NETWORK_ID,
+        adminClientId: LOCALNET_CLIENT_ID,
+        userIds: workerUsers,
+    })
+}

--- a/examples/portfolio/tests/preapprovals.spec.ts
+++ b/examples/portfolio/tests/preapprovals.spec.ts
@@ -3,6 +3,7 @@
 
 import { test } from '@playwright/test'
 import {
+    createGatewayApi,
     connectGateway,
     createWalletGateway,
     expectTransferOfferGone,
@@ -28,14 +29,16 @@ test('toggle preapproval', async ({ page: dappPage }) => {
     const rnd = Math.floor(Math.random() * 100000)
     const wg = createWalletGateway(dappPage)
 
-    await gotoConnect(dappPage)
-    await connectGateway(wg)
-
-    const alice = await wg.createWalletIfNotExists({
+    // Scaffolding: this test is about the preapproval toggle, not about setup.
+    const api = await createGatewayApi()
+    await api.createWallet({
         partyHint: `alice-${rnd}`,
         signingProvider: 'participant',
+        primary: true,
     })
-    await wg.setPrimaryWallet(alice)
+
+    await gotoConnect(dappPage)
+    await connectGateway(wg)
 
     await setupRegistry(dappPage)
 
@@ -57,20 +60,22 @@ test('one step transfer to preapproved receiver', async ({
     const rnd = Math.floor(Math.random() * 100000)
     const wg = createWalletGateway(dappPage)
 
-    await gotoConnect(dappPage)
-    await connectGateway(wg)
-
-    const alice = await wg.createWalletIfNotExists({
+    // Scaffolding: both wallets come from the wallet's API. Bob is primary
+    // because the test funds and preapproves him first.
+    const api = await createGatewayApi()
+    const alice = await api.createWallet({
         partyHint: `alice-${rnd}`,
         signingProvider: 'participant',
     })
-    const bob = await wg.createWalletIfNotExists({
+    const bob = await api.createWallet({
         partyHint: `bob-${rnd}`,
         signingProvider: 'participant',
+        primary: true,
     })
 
-    // Bob: fund the wallet and enable the amulet preapproval.
-    await wg.setPrimaryWallet(bob)
+    await gotoConnect(dappPage)
+    await connectGateway(wg)
+
     await setupRegistry(dappPage)
     await tap(dappPage, wg, '1000')
     await togglePreapproval(dappPage, wg, {
@@ -79,7 +84,7 @@ test('one step transfer to preapproved receiver', async ({
     })
 
     // Alice: tap and transfer to bob.
-    await switchWallet(dappPage, wg, alice)
+    await switchWallet(api, alice)
     await tap(dappPage, wg, '500')
 
     const message = 'preapproved transfer test ' + Date.now()
@@ -92,7 +97,7 @@ test('one step transfer to preapproved receiver', async ({
 
     // Bob: the transfer completes in one step, so no offer requires action
     // and the amount lands directly in bob's balance without accepting.
-    await switchWallet(dappPage, wg, bob)
+    await switchWallet(api, bob)
     await gotoDashboard(dappPage)
     await expectTransferOfferGone(dappPage, { amount: '100', message })
     await expectWalletBalance(dappPage, bob, '1100')

--- a/examples/portfolio/tests/preapprovals.spec.ts
+++ b/examples/portfolio/tests/preapprovals.spec.ts
@@ -3,6 +3,7 @@
 
 import { test } from '@playwright/test'
 import {
+    connectGateway,
     createWalletGateway,
     expectTransferOfferGone,
     expectWalletBalance,
@@ -15,32 +16,20 @@ import {
     tap,
     togglePreapproval,
 } from './utils'
-import { fundValidatorOperator } from './fund-validator'
 
 const AMULET_INSTRUMENT = 'Amulet (AMT)'
-
-// Preapproval tests share wallet gateway state (primary wallet) with the backend,
-// so they must run serially to avoid races on which wallet is primary.
-test.describe.configure({ mode: 'serial' })
 
 // Preapproval tests involve multiple ledger transactions (taps + preapproval
 // toggles + transfer), and enabling an amulet preapproval waits for validator
 // automation, so give them much more time than the default 30s.
 test.setTimeout(300_000)
 
-// The validator operator pays the preapproval purchase fee when accepting a
-// preapproval proposal. On a fresh LocalNet (e.g. CI) the operator holds no
-// amulet, so fund it first or proposals are never accepted.
-test.beforeAll(async () => {
-    await fundValidatorOperator()
-})
-
 test('toggle preapproval', async ({ page: dappPage }) => {
     const rnd = Math.floor(Math.random() * 100000)
     const wg = createWalletGateway(dappPage)
 
     await gotoConnect(dappPage)
-    await wg.connect({ network: 'LocalNet' })
+    await connectGateway(wg)
 
     const alice = await wg.createWalletIfNotExists({
         partyHint: `alice-${rnd}`,
@@ -69,7 +58,7 @@ test('one step transfer to preapproved receiver', async ({
     const wg = createWalletGateway(dappPage)
 
     await gotoConnect(dappPage)
-    await wg.connect({ network: 'LocalNet' })
+    await connectGateway(wg)
 
     const alice = await wg.createWalletIfNotExists({
         partyHint: `alice-${rnd}`,

--- a/examples/portfolio/tests/settings.spec.ts
+++ b/examples/portfolio/tests/settings.spec.ts
@@ -6,6 +6,7 @@ import type { PartyId } from '@canton-network/core-types'
 import { toPortfolioInstrument } from '../src/types/instruments'
 import { normalizeRegistryUrl } from '../src/utils/registry'
 import {
+    connectGateway,
     createWalletGateway,
     expectWalletBalance,
     gotoConnect,
@@ -24,7 +25,7 @@ const connectToSettings = async (page: Page) => {
     const wg = createWalletGateway(page)
 
     await gotoConnect(page)
-    await wg.connect({ network: 'LocalNet' })
+    await connectGateway(wg)
     await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible({
         timeout: 15000,
     })
@@ -250,7 +251,7 @@ test('tap via settings page', async ({ page: dappPage }) => {
     const wg = createWalletGateway(dappPage)
 
     await gotoConnect(dappPage)
-    await wg.connect({ network: 'LocalNet' })
+    await connectGateway(wg)
 
     const alice = await wg.createWalletIfNotExists({
         partyHint: `alice-${rnd}`,

--- a/examples/portfolio/tests/settings.spec.ts
+++ b/examples/portfolio/tests/settings.spec.ts
@@ -6,6 +6,7 @@ import type { PartyId } from '@canton-network/core-types'
 import { toPortfolioInstrument } from '../src/types/instruments'
 import { normalizeRegistryUrl } from '../src/utils/registry'
 import {
+    createGatewayApi,
     connectGateway,
     createWalletGateway,
     expectWalletBalance,
@@ -250,14 +251,16 @@ test('tap via settings page', async ({ page: dappPage }) => {
     const rnd = Math.floor(Math.random() * 100000)
     const wg = createWalletGateway(dappPage)
 
-    await gotoConnect(dappPage)
-    await connectGateway(wg)
-
-    const alice = await wg.createWalletIfNotExists({
+    // Scaffolding: this test is about the tap flow, not about creating wallets.
+    const api = await createGatewayApi()
+    const alice = await api.createWallet({
         partyHint: `alice-${rnd}`,
         signingProvider: 'participant',
+        primary: true,
     })
-    await wg.setPrimaryWallet(alice)
+
+    await gotoConnect(dappPage)
+    await connectGateway(wg)
 
     await setupRegistry(dappPage)
     await tap(dappPage, wg, '5000.123456789')

--- a/examples/portfolio/tests/transaction-history.spec.ts
+++ b/examples/portfolio/tests/transaction-history.spec.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, type Locator, type Page, test } from '@playwright/test'
-import { fundValidatorOperator } from './fund-validator'
 import {
+    connectGateway,
     createWalletGateway,
     fillAndSubmitTransfer,
     gotoConnect,
@@ -26,18 +26,9 @@ type ExpectedTransaction = {
     counterpartyHint?: string
 }
 
-// Transaction history tests share wallet gateway state (primary wallet) with
-// the backend, so they must run serially.
-test.describe.configure({ mode: 'serial' })
-
 // This flow includes taps, preapproval automation, a direct transfer, and an
 // accepted transfer offer.
 test.setTimeout(300_000)
-
-// The validator operator pays the fee for accepting an amulet preapproval.
-test.beforeAll(async () => {
-    await fundValidatorOperator()
-})
 
 const gotoWalletHistory = async (
     page: Page,
@@ -131,7 +122,7 @@ test('shows taps, direct transfers, and transfer offers for both parties', async
     const wg = createWalletGateway(dappPage)
 
     await gotoConnect(dappPage)
-    await wg.connect({ network: 'LocalNet' })
+    await connectGateway(wg)
 
     const alice = await wg.createWalletIfNotExists({
         partyHint: aliceHint,

--- a/examples/portfolio/tests/transaction-history.spec.ts
+++ b/examples/portfolio/tests/transaction-history.spec.ts
@@ -3,6 +3,7 @@
 
 import { expect, type Locator, type Page, test } from '@playwright/test'
 import {
+    createGatewayApi,
     connectGateway,
     createWalletGateway,
     fillAndSubmitTransfer,
@@ -121,24 +122,26 @@ test('shows taps, direct transfers, and transfer offers for both parties', async
     const bobHint = `b-${rnd}`
     const wg = createWalletGateway(dappPage)
 
-    await gotoConnect(dappPage)
-    await connectGateway(wg)
-
-    const alice = await wg.createWalletIfNotExists({
+    // Scaffolding: both wallets are created through the wallet's API, so the UI
+    // is only driven for what this test asserts (the history entries).
+    const api = await createGatewayApi()
+    const alice = await api.createWallet({
         partyHint: aliceHint,
         signingProvider: 'participant',
+        primary: true,
     })
-    const bob = await wg.createWalletIfNotExists({
+    const bob = await api.createWallet({
         partyHint: bobHint,
         signingProvider: 'participant',
     })
 
-    await wg.setPrimaryWallet(alice)
+    await gotoConnect(dappPage)
+    await connectGateway(wg)
     await setupRegistry(dappPage)
 
     // Both taps should appear as incoming history entries.
     await tap(dappPage, wg, '1000')
-    await switchWallet(dappPage, wg, bob)
+    await switchWallet(api, bob)
     await tap(dappPage, wg, '500')
 
     // Bob's preapproval makes Alice -> Bob a direct, one-step transfer.
@@ -146,7 +149,7 @@ test('shows taps, direct transfers, and transfer offers for both parties', async
         instrument: AMULET_INSTRUMENT,
         enabled: true,
     })
-    await switchWallet(dappPage, wg, alice)
+    await switchWallet(api, alice)
     await gotoDashboard(dappPage)
     await openTransferDialog(dappPage)
     await fillAndSubmitTransfer(dappPage, wg, {
@@ -156,7 +159,7 @@ test('shows taps, direct transfers, and transfer offers for both parties', async
     })
 
     // Alice has no preapproval, so Bob -> Alice creates a transfer offer.
-    await switchWallet(dappPage, wg, bob)
+    await switchWallet(api, bob)
     await gotoDashboard(dappPage)
     await openTransferDialog(dappPage)
     const offerMessage = `offer history ${Date.now()}`
@@ -168,7 +171,7 @@ test('shows taps, direct transfers, and transfer offers for both parties', async
 
     // Load Alice's history before accepting to verify the pending lifecycle
     // entry and exercise transaction-history cache invalidation on acceptance.
-    await switchWallet(dappPage, wg, alice)
+    await switchWallet(api, alice)
     await gotoWalletHistory(dappPage, alice, aliceHint)
     await expectTransactionRow(dappPage, {
         activity: 'Offer received ↘',

--- a/examples/portfolio/tests/transfers.spec.ts
+++ b/examples/portfolio/tests/transfers.spec.ts
@@ -4,6 +4,7 @@
 import { test, expect, Page } from '@playwright/test'
 import { WalletGateway } from '@canton-network/core-wallet-test-utils'
 import {
+    connectGateway,
     createWalletGateway,
     expectOffersBadgeCount,
     expectTransferOfferGone,
@@ -20,10 +21,6 @@ import {
     tap,
 } from './utils'
 
-// Transfer tests share wallet gateway state (primary wallet) with the backend,
-// so they must run serially to avoid races on which wallet is primary.
-test.describe.configure({ mode: 'serial' })
-
 // Transfer tests involve multiple ledger transactions (tap + transfer + accept/reject/withdraw),
 // so give them more time than the default 30s.
 test.setTimeout(120_000)
@@ -39,7 +36,7 @@ const setupTransferTest = async (page: Page): Promise<TransferTestContext> => {
     const wg = createWalletGateway(page)
 
     await gotoConnect(page)
-    await wg.connect({ network: 'LocalNet' })
+    await connectGateway(wg)
 
     const alice = await wg.createWalletIfNotExists({
         partyHint: `alice-${rnd}`,

--- a/examples/portfolio/tests/transfers.spec.ts
+++ b/examples/portfolio/tests/transfers.spec.ts
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { test, expect, Page } from '@playwright/test'
-import { WalletGateway } from '@canton-network/core-wallet-test-utils'
 import {
+    GatewayUserApi,
+    WalletGateway,
+} from '@canton-network/core-wallet-test-utils'
+import {
+    createGatewayApi,
     connectGateway,
     createWalletGateway,
     expectOffersBadgeCount,
@@ -27,6 +31,7 @@ test.setTimeout(120_000)
 
 interface TransferTestContext {
     wg: WalletGateway
+    api: GatewayUserApi
     alice: string
     bob: string
 }
@@ -35,23 +40,27 @@ const setupTransferTest = async (page: Page): Promise<TransferTestContext> => {
     const rnd = Math.floor(Math.random() * 100000)
     const wg = createWalletGateway(page)
 
-    await gotoConnect(page)
-    await connectGateway(wg)
-
-    const alice = await wg.createWalletIfNotExists({
+    // Wallets are scaffolding here, so they are created through the wallet's
+    // API. They exist before the dApp connects, so the dashboard already opens
+    // on alice.
+    const api = await createGatewayApi()
+    const alice = await api.createWallet({
         partyHint: `alice-${rnd}`,
         signingProvider: 'participant',
+        primary: true,
     })
-    const bob = await wg.createWalletIfNotExists({
+    const bob = await api.createWallet({
         partyHint: `bob-${rnd}`,
         signingProvider: 'participant',
     })
 
-    await wg.setPrimaryWallet(alice)
+    await gotoConnect(page)
+    await connectGateway(wg)
+
     await setupRegistry(page)
     await gotoDashboard(page)
 
-    return { wg, alice, bob }
+    return { wg, api, alice, bob }
 }
 
 test.describe('dashboard transfer flow', () => {
@@ -98,7 +107,7 @@ test.describe('dashboard transfer flow', () => {
     })
 
     test('two step transfer - accept', async ({ page: dappPage }) => {
-        const { wg, alice, bob } = await setupTransferTest(dappPage)
+        const { wg, api, alice, bob } = await setupTransferTest(dappPage)
 
         // Alice: tap and create transfer.
         await tap(dappPage, wg, '1234')
@@ -123,7 +132,7 @@ test.describe('dashboard transfer flow', () => {
         await expectOffersBadgeCount(dappPage, 1)
 
         // Switch to bob to see the pending transfer as receiver.
-        await switchWallet(dappPage, wg, bob)
+        await switchWallet(api, bob)
         await gotoDashboard(dappPage)
 
         // Bob's incoming offer is counted on the sidebar badge.
@@ -145,12 +154,12 @@ test.describe('dashboard transfer flow', () => {
         await expectOffersBadgeCount(dappPage, 0)
 
         // Verify alice's balance decreased.
-        await switchWallet(dappPage, wg, alice)
+        await switchWallet(api, alice)
         await expectWalletBalance(dappPage, alice, '913')
     })
 
     test('two step transfer - rejection', async ({ page: dappPage }) => {
-        const { wg, alice, bob } = await setupTransferTest(dappPage)
+        const { wg, api, alice, bob } = await setupTransferTest(dappPage)
 
         // Alice: tap and create transfer.
         await tap(dappPage, wg, '500')
@@ -164,7 +173,7 @@ test.describe('dashboard transfer flow', () => {
         })
 
         // Switch to bob to see the pending transfer as receiver.
-        await switchWallet(dappPage, wg, bob)
+        await switchWallet(api, bob)
         await gotoDashboard(dappPage)
 
         const dialog = await openTransferOfferDialog(dappPage, {
@@ -181,18 +190,18 @@ test.describe('dashboard transfer flow', () => {
         await expectTransferOfferGone(dappPage, { amount: '100', message })
 
         // Verify alice's balance is restored after rejection.
-        await switchWallet(dappPage, wg, alice)
+        await switchWallet(api, alice)
         await expectWalletBalance(dappPage, alice, '500')
 
         // Verify bob has no holdings.
-        await switchWallet(dappPage, wg, bob)
+        await switchWallet(api, bob)
         await expectWalletHasNoAssets(dappPage, bob)
     })
 
     test('two step transfer - withdrawal by sender', async ({
         page: dappPage,
     }) => {
-        const { wg, alice, bob } = await setupTransferTest(dappPage)
+        const { wg, api, alice, bob } = await setupTransferTest(dappPage)
 
         // Alice: tap and create transfer.
         await tap(dappPage, wg, '500')
@@ -207,7 +216,7 @@ test.describe('dashboard transfer flow', () => {
 
         // Re-assert alice as primary wallet and wait for the outgoing transfer
         // to load on Offers.
-        await switchWallet(dappPage, wg, alice)
+        await switchWallet(api, alice)
         await gotoOffers(dappPage)
         const loadedDialog = await openTransferOfferDialog(dappPage, {
             amount: '100',
@@ -238,12 +247,12 @@ test.describe('dashboard transfer flow', () => {
         await expectWalletBalance(dappPage, alice, '500')
 
         // Verify bob has no holdings.
-        await switchWallet(dappPage, wg, bob)
+        await switchWallet(api, bob)
         await expectWalletHasNoAssets(dappPage, bob)
     })
 
     test('transfer detail dialog', async ({ page: dappPage }) => {
-        const { wg, bob } = await setupTransferTest(dappPage)
+        const { wg, api, bob } = await setupTransferTest(dappPage)
 
         // Alice: tap and create transfer.
         await tap(dappPage, wg, '800')
@@ -257,7 +266,7 @@ test.describe('dashboard transfer flow', () => {
         })
 
         // Switch to bob (receiver) to see the transfer.
-        await switchWallet(dappPage, wg, bob)
+        await switchWallet(api, bob)
         await gotoDashboard(dappPage)
 
         const dialog = await openTransferOfferDialog(dappPage, {

--- a/examples/portfolio/tests/utils.ts
+++ b/examples/portfolio/tests/utils.ts
@@ -1,10 +1,45 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect, Page } from '@playwright/test'
+import { expect, Page, test } from '@playwright/test'
 import { WalletGateway } from '@canton-network/core-wallet-test-utils'
 
 const BASE_URL = 'http://localhost:8081'
+
+// Gateway and LocalNet network the dApp uses in dev and CI. The gateway's
+// config for that network authenticates with the `ledger-api-user` client id,
+// and a user with that same id exists on the participant.
+export const GATEWAY_URL = 'http://localhost:3030'
+export const LOCALNET_NETWORK_ID = 'canton:localnet'
+export const LOCALNET_CLIENT_ID = 'ledger-api-user'
+// Participant behind that network.
+export const LOCALNET_LEDGER_API_URL = 'http://localhost:2975'
+
+/**
+ * Gateway user id for a worker.
+ *
+ * Wallets and the primary wallet are scoped per gateway user, so giving each
+ * worker its own user keeps parallel tests from stepping on each other.
+ *
+ * Worker 0 reuses LOCALNET_CLIENT_ID, which already has a user on the
+ * participant, so a single-worker run needs nothing created up front.
+ */
+export const gatewayUserForWorker = (index: number): string =>
+    index === 0 ? LOCALNET_CLIENT_ID : `${LOCALNET_CLIENT_ID}-w${index}`
+
+/**
+ * Gateway user id for the worker running the current test.
+ *
+ * `parallelIndex` and not `workerIndex`: it never exceeds the worker count and
+ * is reused when a worker restarts, so retries do not keep creating new users.
+ */
+const workerClientId = (): string =>
+    gatewayUserForWorker(test.info().parallelIndex)
+
+/** Connect the dApp to the gateway as this worker's user. */
+export const connectGateway = async (wg: WalletGateway): Promise<void> => {
+    await wg.connect({ network: 'LocalNet', clientId: workerClientId() })
+}
 
 export const createWalletGateway = (dappPage: Page): WalletGateway =>
     new WalletGateway({

--- a/examples/portfolio/tests/utils.ts
+++ b/examples/portfolio/tests/utils.ts
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, Page, test } from '@playwright/test'
-import { WalletGateway } from '@canton-network/core-wallet-test-utils'
+import {
+    GatewayUserApi,
+    WalletGateway,
+} from '@canton-network/core-wallet-test-utils'
 
 const BASE_URL = 'http://localhost:8081'
 
@@ -36,7 +39,32 @@ export const gatewayUserForWorker = (index: number): string =>
 const workerClientId = (): string =>
     gatewayUserForWorker(test.info().parallelIndex)
 
-/** Connect the dApp to the gateway as this worker's user. */
+/**
+ * Open a gateway User API session, to set up wallets by calling the wallet
+ * instead of driving its web UI.
+ *
+ * These tests assert on the dApp. Creating wallets is just scaffolding, and
+ * doing it through the wallet UI costs a page load per call.
+ */
+export const createGatewayApi = async (): Promise<GatewayUserApi> => {
+    const api = new GatewayUserApi({
+        baseUrl: GATEWAY_URL,
+        networkId: LOCALNET_NETWORK_ID,
+        clientId: workerClientId(),
+        // Not the dApp origin: sessions are per (user, origin) and a new one
+        // replaces the old, so the dApp's connect would kill this session.
+        origin: `http://portfolio-e2e-setup-w${test.info().parallelIndex}`,
+    })
+    await api.connect()
+    return api
+}
+
+/**
+ * Connect the dApp to the gateway as this worker's user.
+ *
+ * Must use the same client id as `createGatewayApi`. The dApp only sees wallets
+ * belonging to the user it connected as.
+ */
 export const connectGateway = async (wg: WalletGateway): Promise<void> => {
     await wg.connect({ network: 'LocalNet', clientId: workerClientId() })
 }
@@ -253,20 +281,16 @@ export const expectOffersBadgeCount = async (
     await expect(badge).toHaveText(String(count), { timeout: 15000 })
 }
 
+/**
+ * Make `partyId` the primary wallet, by calling the wallet instead of clicking
+ * its UI. The gateway emits `accountsChanged` either way, so the dApp reacts
+ * the same.
+ */
 export const switchWallet = async (
-    page: Page,
-    wg: WalletGateway,
+    api: GatewayUserApi,
     partyId: string
 ): Promise<void> => {
-    await expect(
-        page.getByRole('button', { name: 'Wallet Gateway' })
-    ).toBeVisible()
-
-    if (!(await wg.isPopupOpen())) {
-        await wg.openPopup()
-    }
-
-    await wg.setPrimaryWallet(partyId)
+    await api.setPrimaryWallet(partyId)
 }
 
 export const expectWalletBalance = async (

--- a/examples/portfolio/tests/wallet-detail.spec.ts
+++ b/examples/portfolio/tests/wallet-detail.spec.ts
@@ -3,6 +3,7 @@
 
 import { test, expect } from '@playwright/test'
 import {
+    connectGateway,
     createWalletGateway,
     gotoConnect,
     gotoDashboard,
@@ -21,7 +22,7 @@ test('wallet detail page - assets and transaction history', async ({
     const wg = createWalletGateway(dappPage)
 
     await gotoConnect(dappPage)
-    await wg.connect({ network: 'LocalNet' })
+    await connectGateway(wg)
 
     const aliceHint = `alice-${rnd}`
     const alice = await wg.createWalletIfNotExists({

--- a/examples/portfolio/tests/wallet-detail.spec.ts
+++ b/examples/portfolio/tests/wallet-detail.spec.ts
@@ -3,6 +3,7 @@
 
 import { test, expect } from '@playwright/test'
 import {
+    createGatewayApi,
     connectGateway,
     createWalletGateway,
     gotoConnect,
@@ -21,16 +22,19 @@ test('wallet detail page - assets and transaction history', async ({
     const rnd = Math.floor(Math.random() * 100000)
     const wg = createWalletGateway(dappPage)
 
+    // Scaffolding: the wallet just has to exist and be primary, so it is
+    // created through the wallet's API instead of its UI.
+    const api = await createGatewayApi()
+    const aliceHint = `alice-${rnd}`
+    await api.createWallet({
+        partyHint: aliceHint,
+        signingProvider: 'participant',
+        primary: true,
+    })
+
     await gotoConnect(dappPage)
     await connectGateway(wg)
 
-    const aliceHint = `alice-${rnd}`
-    const alice = await wg.createWalletIfNotExists({
-        partyHint: aliceHint,
-        signingProvider: 'participant',
-    })
-
-    await wg.setPrimaryWallet(alice)
     await setupRegistry(dappPage)
     await tap(dappPage, wg, '2000')
     await gotoDashboard(dappPage)

--- a/examples/portfolio/vite.config.ts
+++ b/examples/portfolio/vite.config.ts
@@ -27,4 +27,9 @@ export default defineConfig({
     server: {
         port: 8081,
     },
+    // e2e (and the CI job) hit this app on 8081 whether it is served from the
+    // dev server or from the build.
+    preview: {
+        port: 8081,
+    },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1763,9 +1763,21 @@ importers:
 
   core/wallet-test-utils:
     dependencies:
+      '@canton-network/core-ledger-client':
+        specifier: workspace:^
+        version: link:../ledger-client
+      '@canton-network/core-rpc-transport':
+        specifier: workspace:^
+        version: link:../rpc-transport
       '@canton-network/core-types':
         specifier: workspace:^
         version: link:../types
+      '@canton-network/core-wallet-auth':
+        specifier: workspace:^
+        version: link:../wallet-auth
+      '@canton-network/core-wallet-user-rpc-client':
+        specifier: workspace:^
+        version: link:../wallet-user-rpc-client
       '@canton-network/wallet-sdk':
         specifier: workspace:^
         version: link:../../sdk/wallet-sdk


### PR DESCRIPTION
Closes #2363.

`portfolio-e2e` takes 21 minutes and runs twice per PR, so it sets the wall clock
for the whole run. Three independent commits:

b77d8573 serves the dApp from the production build instead of the Vite dev server.
In dev the browser pulls hundreds of unbundled modules per page, which shows up on
every screen the tests open; from the build, each one loads in about half the time.
The build already happened in CI, it just was not in the artifact the e2e jobs
download.

43436991 runs the tests on two workers. They mostly wait on the ledger rather than
use CPU, so overlapping them is nearly free: a full local run went from 11.6 to 6.5
minutes with per-step latencies unchanged.

What kept them serial was shared state: the gateway scopes wallets, and which one is
primary, per user, and every test connected as the same user. Each worker now
connects as its own, derived from the Playwright parallel index. That id also travels
to the participant as the token subject, and Canton rejects subjects it does not
know, so a new global setup creates those users first.

fefe8911 changes how the tests set up their wallets. They used to create parties and
pick the primary wallet by clicking through the gateway's web UI, which meant
reloading its parties page 78 times across the suite, about 1.5s each, for something
no test actually asserts. The helpers now call the gateway's User API directly, the
same JSON-RPC methods that UI uses under the hood. Approving transactions still goes
through the UI, since that is the integration under test. On the transfers spec,
setup went from 79s to 37s.

The numbers come from a dev machine with 8 cores. CI runners have 4, and Canton plus
splice take about 2 before any test starts, so expect less there. Four workers was
already worse than two locally.

contributed by [bootnode.dev](http://bootnode.dev/)