### PR TITLE
fix(wallet-gateway-remote): include sign-message and api-keys pages i…

### DIFF
--- a/wallet-gateway/remote/vite.config.ts
+++ b/wallet-gateway/remote/vite.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
                     __dirname,
                     'src/web/frontend/approve/index.html'
                 ),
+                signMessage: resolve(
+                    __dirname,
+                    'src/web/frontend/sign-message/index.html'
+                ),
                 callback: resolve(
                     __dirname,
                     'src/web/frontend/callback/index.html'
@@ -40,6 +44,14 @@ export default defineConfig({
                 settings: resolve(
                     __dirname,
                     'src/web/frontend/settings/index.html'
+                ),
+                apiKeys: resolve(
+                    __dirname,
+                    'src/web/frontend/api-keys/index.html'
+                ),
+                addApiKey: resolve(
+                    __dirname,
+                    'src/web/frontend/api-keys/add/index.html'
                 ),
                 activities: resolve(
                     __dirname,


### PR DESCRIPTION
## Problem

Three pages exist under `wallet-gateway/remote/src/web/frontend/` and are declared as
valid routes in `ALLOWED_ROUTES` (`core/wallet-ui-components/src/routing.ts`), but are
missing from the Vite multi-page `rollupOptions.input`, so they are never emitted:

- `sign-message/`
- `api-keys/`
- `api-keys/add/`

The source tree has 18 `index.html` entry points; the build config lists 15.

### User-visible impact: `signMessage` is unreachable over the dApp API

`wallet-gateway/remote/src/dapp-api/controller.ts` returns

```
userUrl: `${userUrl}/sign-message/index.html?messageId=${messageId}&closeafteraction`
```

and `@canton-network/dapp-sdk` opens that URL in a popup. Because the page is not in the
build output, the popup lands on a 404 and the signing request can never be approved —
`signMessage` times out for every dApp using a remote Wallet Gateway.

Reproduced against the published artifact, not just the source tree: the
`@canton-network/wallet-gateway-remote@1.9.0` tarball (the exact package installed by
`ghcr.io/digital-asset/wallet-gateway/docker/wallet-gateway`) contains no
`dist/web/frontend/sign-message/` directory, and no chunk in `dist/web/frontend/assets/`
references `user-ui-sign-message` or `getMessageToSign`. The gateway serves that directory
with a plain `express.static()`, so a missing entry point is an unconditional 404.

### How it got missed

`sign-message/` was added in #1718 (2026-05-18), which wired up the dApp API, the RPC
methods and the Lit component (with unit tests), but did not touch
`wallet-gateway/remote/vite.config.ts` — a file unchanged since #1520 (2026-03-31).

This is the same class of regression already fixed once in #1045
("fix: include transactions page in build").

## Fix

Add the three missing entry points to `rollupOptions.input`, grouped next to their
siblings (`signMessage` beside `approve`; `apiKeys`/`addApiKey` beside `settings`,
following the existing `parties`/`addParty` and `networks`/`addNetwork` pattern).

## Verification

`vite build` in `wallet-gateway/remote` now emits 18 pages, matching the 18 entry points
in the source tree (15 before):

```
dist/web/frontend/sign-message/index.html    0.54 kB
dist/web/frontend/api-keys/index.html        0.52 kB
dist/web/frontend/api-keys/add/index.html    0.54 kB

dist/web/frontend/assets/signMessage-Iwjt8OJB.js   8.04 kB
dist/web/frontend/assets/apiKeys-C0iup1Nz.js       5.68 kB
dist/web/frontend/assets/addApiKey-B09ZOS9_.js     5.91 kB
```

## Notes

- No source or behaviour change — build configuration only.
- The existing unit tests for these pages
  (`sign-message/index.test.ts`, `api-keys/index.test.ts`, `api-keys/add/index.test.ts`)
  already pass; they were simply testing components that never shipped.
- Consider a follow-up guard so a page under `src/web/frontend/` that is missing from
  `rollupOptions.input` fails CI — this is the second occurrence.