### PR TITLE
perf(example-portfolio): collapse per-row preapproval status queries

### DIFF
--- a/examples/portfolio/src/components/settings/preapprovals-section.tsx
+++ b/examples/portfolio/src/components/settings/preapprovals-section.tsx
@@ -36,7 +36,7 @@ export function PreapprovalsSection() {
         refresh,
     } = useWalletSdk()
     const rows = usePreapprovalRows()
-    const statusQueries = usePreapprovalStatuses({
+    const statuses = usePreapprovalStatuses({
         rows,
         primaryParty,
         sdk,
@@ -114,14 +114,13 @@ export function PreapprovalsSection() {
                     <TableBody>
                         {rows.length > 0 ? (
                             rows.map((row, index) => {
-                                const statusQuery = statusQueries[index]
-                                const hasError = Boolean(statusQuery?.isError)
-                                const enabled = Boolean(statusQuery?.data)
-                                // A failed status query is "resolved" (we stop
+                                const status = statuses[index]
+                                const hasError = status.isError
+                                const enabled = status.isEnabled
+                                // A failed status read is "resolved" (we stop
                                 // showing "Checking...") but the ledger state
                                 // is unknown, so never present it as Disabled.
-                                const hasResolvedStatus =
-                                    statusQuery?.data !== undefined || hasError
+                                const hasResolvedStatus = !status.isLoading
                                 const isInitialCheck =
                                     !hasResolvedStatus || isWalletSdkLoading
                                 const isUpdating =
@@ -198,7 +197,7 @@ export function PreapprovalsSection() {
                                                         color="inherit"
                                                         size="small"
                                                         onClick={() =>
-                                                            statusQuery?.refetch()
+                                                            status.refetch()
                                                         }
                                                     >
                                                         Retry

--- a/examples/portfolio/src/hooks/query-keys.ts
+++ b/examples/portfolio/src/hooks/query-keys.ts
@@ -64,27 +64,18 @@ export const queryKeys = {
                 ] as const,
         },
 
+        // Both reads take a party and nothing else. Naming the instrument
+        // here would run the same read once per row.
         preapprovals: {
             all: [...walletConnection, 'preapprovals'] as const,
-            status: ({
-                party,
-                kind,
-                registryPartyId,
-                instrumentId,
-            }: {
-                party: string | undefined
-                kind: string
-                registryPartyId: string
-                instrumentId: string
-            }) =>
+            amulet: (party: string | undefined) =>
+                [...walletConnection, 'preapprovals', 'amulet', party] as const,
+            utility: (party: string | undefined) =>
                 [
                     ...walletConnection,
                     'preapprovals',
-                    'status',
+                    'utility',
                     party,
-                    kind,
-                    registryPartyId,
-                    instrumentId,
                 ] as const,
         },
     },

--- a/examples/portfolio/src/hooks/query-options.ts
+++ b/examples/portfolio/src/hooks/query-options.ts
@@ -1,13 +1,12 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { queryOptions, type QueryClient } from '@tanstack/react-query'
+import { queryOptions } from '@tanstack/react-query'
 import * as dappSdk from '@canton-network/dapp-sdk'
 import type { LedgerProvider } from '@canton-network/core-provider-ledger'
 import { usePortfolioConfig } from '../contexts/PortfolioConfigContext'
 import { queryKeys } from './query-keys'
 import { useWalletSdk, type WalletSdk } from './useWalletSdk'
-import type { PreapprovalRow } from '../types/preapprovals'
 import { logger } from '@lib/logger'
 import { TransactionHistoryService } from '@services/transaction-history-service'
 import { toUniquePortfolioHoldings } from '@utils/holdings'
@@ -51,7 +50,9 @@ export const utilityOperatorQueryOptions = ({
         },
         // The operator party for a registry is fixed, so cache it forever and
         // let consumers re-fetch on demand when a lookup previously failed.
+        // Rows subscribe to it now, so it must skip the polling interval too.
         staleTime: Infinity,
+        refetchInterval: false as const,
     })
 
 export const transactionHistoryServiceQueryOptions = (partyId: string) =>
@@ -175,52 +176,47 @@ export const useIsDevNetQueryOptions = () => {
     })
 }
 
-export const preapprovalStatusQueryOptions = ({
-    row,
+// Match the SDK's 10-second preapproval visibility polling interval.
+const PREAPPROVAL_STALE_TIME = 10_000
+
+/** The party's Amulet preapproval. Every Amulet row shares this query. */
+export const amuletPreapprovalQueryOptions = ({
     party,
     sdk,
-    queryClient,
 }: {
-    row: PreapprovalRow
     party: string | undefined
     sdk: WalletSdk
-    queryClient: QueryClient
 }) =>
     queryOptions({
-        queryKey: queryKeys.walletConnection.preapprovals.status({
-            party,
-            kind: row.kind,
-            registryPartyId: row.registryPartyId,
-            instrumentId: row.instrument.id,
-        }),
+        queryKey: queryKeys.walletConnection.preapprovals.amulet(party),
         enabled: !!party && !!sdk,
-        // Match the SDK's 10-second preapproval visibility polling interval.
-        staleTime: 10_000,
+        staleTime: PREAPPROVAL_STALE_TIME,
         queryFn: async () => {
             if (!party || !sdk) {
                 return null
             }
 
-            if (row.kind === 'amulet') {
-                return (await sdk.amulet.preapproval.fetchQuick(party)) ?? null
+            return (await sdk.amulet.preapproval.fetchQuick(party)) ?? null
+        },
+    })
+
+/** All the party's utility preapprovals, in one scan for the whole table. */
+export const utilityPreapprovalsQueryOptions = ({
+    party,
+    sdk,
+}: {
+    party: string | undefined
+    sdk: WalletSdk
+}) =>
+    queryOptions({
+        queryKey: queryKeys.walletConnection.preapprovals.utility(party),
+        enabled: !!party && !!sdk,
+        staleTime: PREAPPROVAL_STALE_TIME,
+        queryFn: async () => {
+            if (!party || !sdk) {
+                return []
             }
 
-            // The operator party is a precondition for the utility status
-            // lookup. Resolving it here means a failed operator fetch surfaces
-            // through this query's error state (and its retry), rather than
-            // leaving the row stuck on "Checking...".
-            const operator = await queryClient.ensureQueryData(
-                utilityOperatorQueryOptions({
-                    registryPartyId: row.registryPartyId,
-                    registryUrl: row.registryUrl,
-                })
-            )
-
-            return await sdk.utilities.preapprovalTransfer.fetchQuick({
-                receiver: party,
-                operator,
-                instrumentAdmin: row.registryPartyId,
-                instrumentId: row.instrument.id,
-            })
+            return await sdk.utilities.preapprovalTransfer.list(party)
         },
     })

--- a/examples/portfolio/src/hooks/usePreapprovalStatuses.ts
+++ b/examples/portfolio/src/hooks/usePreapprovalStatuses.ts
@@ -1,8 +1,14 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useQueries, useQueryClient } from '@tanstack/react-query'
-import { preapprovalStatusQueryOptions } from './query-options'
+import { useMemo } from 'react'
+import { useQueries, useQuery } from '@tanstack/react-query'
+import {
+    amuletPreapprovalQueryOptions,
+    utilityOperatorQueryOptions,
+    utilityPreapprovalsQueryOptions,
+} from './query-options'
+import { findPreapproval } from '@lib/utilities-wallet-sdk-plugin'
 import type { WalletSdk } from './useWalletSdk'
 import type { PreapprovalRow } from '../types/preapprovals'
 
@@ -12,23 +18,115 @@ type UsePreapprovalStatusesArgs = {
     sdk: WalletSdk
 }
 
+/** A row combines up to three queries, so it carries its own flags. */
+export type PreapprovalStatus = {
+    isEnabled: boolean
+    isLoading: boolean
+    isError: boolean
+    refetch: () => void
+}
+
+/** Reads preapprovals once per party, then works out each row from that. */
 export function usePreapprovalStatuses({
     rows,
     primaryParty,
     sdk,
-}: UsePreapprovalStatusesArgs) {
-    const queryClient = useQueryClient()
+}: UsePreapprovalStatusesArgs): PreapprovalStatus[] {
+    // Amulet preapprovals of the party
+    const amuletPreapproval = useQuery(
+        amuletPreapprovalQueryOptions({ party: primaryParty, sdk })
+    )
+    // utility preapprovals of the party
+    const utilityPreapprovals = useQuery(
+        utilityPreapprovalsQueryOptions({ party: primaryParty, sdk })
+    )
 
-    // TODO: https://github.com/canton-network/wallet/issues/2062
-    // collapse N per-row status queries into one query per party.
-    return useQueries({
-        queries: rows.map((row) =>
-            preapprovalStatusQueryOptions({
-                row,
-                party: primaryParty,
-                sdk,
-                queryClient,
-            })
-        ),
+    // The registries behind the utility rows, without repeats.
+    const registries = useMemo(
+        () =>
+            Array.from(
+                new Map(
+                    rows
+                        .filter((row) => row.kind === 'utility')
+                        .map((row) => [
+                            row.registryPartyId,
+                            {
+                                registryPartyId: row.registryPartyId,
+                                registryUrl: row.registryUrl,
+                            },
+                        ])
+                ).values()
+            ),
+        [rows]
+    )
+
+    // The operator party of each registry.
+    const operatorQueries = useQueries({
+        queries: registries.map((registry) => ({
+            ...utilityOperatorQueryOptions(registry),
+            enabled: !!primaryParty && !!sdk,
+        })),
+    })
+
+    return rows.map((row) => {
+        if (row.kind === 'amulet') {
+            return {
+                isEnabled: Boolean(amuletPreapproval.data),
+                isLoading: amuletPreapproval.isPending,
+                isError: amuletPreapproval.isError,
+                refetch: () => void amuletPreapproval.refetch(),
+            }
+        }
+
+        const operatorQuery =
+            operatorQueries[
+                registries.findIndex(
+                    (registry) =>
+                        registry.registryPartyId === row.registryPartyId
+                )
+            ]
+
+        // Either read could be the one that failed.
+        const refetch = () => {
+            void operatorQuery?.refetch()
+            void utilityPreapprovals.refetch()
+        }
+
+        if (operatorQuery?.isError || utilityPreapprovals.isError) {
+            return {
+                isEnabled: false,
+                isLoading: false,
+                isError: true,
+                refetch,
+            }
+        }
+
+        const operator = operatorQuery?.data
+        if (
+            !primaryParty ||
+            operator === undefined ||
+            utilityPreapprovals.data === undefined
+        ) {
+            return {
+                isEnabled: false,
+                isLoading: true,
+                isError: false,
+                refetch,
+            }
+        }
+
+        const preapproval = findPreapproval(utilityPreapprovals.data, {
+            receiver: primaryParty,
+            operator,
+            instrumentAdmin: row.registryPartyId,
+            instrumentId: row.instrument.id,
+        })
+
+        return {
+            isEnabled: preapproval !== null,
+            isLoading: false,
+            isError: false,
+            refetch,
+        }
     })
 }

--- a/examples/portfolio/src/hooks/useTogglePreapproval.ts
+++ b/examples/portfolio/src/hooks/useTogglePreapproval.ts
@@ -104,13 +104,17 @@ export function useTogglePreapproval({
             ].preapprovalTransfer.fetchStatus(args, { cancelled: true })
         },
         onSuccess: async (_data, variables) => {
+            // The read is shared, so other rows this contract covers
+            // refresh too.
             await queryClient.invalidateQueries({
-                queryKey: queryKeys.walletConnection.preapprovals.status({
-                    party: primaryParty,
-                    kind: variables.row.kind,
-                    registryPartyId: variables.row.registryPartyId,
-                    instrumentId: variables.row.instrument.id,
-                }),
+                queryKey:
+                    variables.row.kind === 'amulet'
+                        ? queryKeys.walletConnection.preapprovals.amulet(
+                              primaryParty
+                          )
+                        : queryKeys.walletConnection.preapprovals.utility(
+                              primaryParty
+                          ),
             })
             toast.success(
                 variables.enabled

--- a/examples/portfolio/src/lib/utilities-wallet-sdk-plugin.ts
+++ b/examples/portfolio/src/lib/utilities-wallet-sdk-plugin.ts
@@ -22,14 +22,14 @@ const EMPTY_COMMAND_RESULT = [null, []] as const
 
 type TransferPreapprovalParty = TransferPreapproval['receiver']
 
-type TransferPreapprovalStatus = {
+export type TransferPreapprovalStatus = {
     contractId: string
     templateId: string
     synchronizerId: string
     payload: TransferPreapproval
 }
 
-type FetchPreapprovalArgs = {
+export type FetchPreapprovalArgs = {
     receiver: TransferPreapprovalParty
     operator: TransferPreapprovalParty
     instrumentAdmin: TransferPreapprovalParty
@@ -83,11 +83,19 @@ export class WalletSDKUtilitiesPlugin extends SDKPlugin {
             return [transferPreapprovalCommand, []]
         },
 
+        /** Reads all preapprovals of a receiver. */
+        list: async (
+            receiver: TransferPreapprovalParty
+        ): Promise<TransferPreapprovalStatus[]> =>
+            this.readTransferPreapprovals(receiver),
+
         fetchQuick: async (
             args: FetchPreapprovalArgs
         ): Promise<TransferPreapprovalStatus | null> => {
-            const preapprovals = await this.readTransferPreapprovals(args)
-            const preapproval = preapprovals[0]
+            const preapprovals = await this.readTransferPreapprovals(
+                args.receiver
+            )
+            const preapproval = findPreapproval(preapprovals, args)
 
             if (!preapproval) {
                 this.ctx.logger.info(args, 'Preapproval is no longer visible')
@@ -190,13 +198,13 @@ export class WalletSDKUtilitiesPlugin extends SDKPlugin {
     }
 
     private async readTransferPreapprovals(
-        args: FetchPreapprovalArgs
+        receiver: TransferPreapprovalParty
     ): Promise<TransferPreapprovalStatus[]> {
         const contracts =
             await this.ctx.namespace.ledger.acsReader.paginated.raw.readJsContracts(
                 {
                     templateIds: [TRANSFER_PREAPPROVAL_TEMPLATE_ID],
-                    parties: [args.receiver],
+                    parties: [receiver],
                     filterByParty: true,
                     continueUntilCompletion: true,
                 }
@@ -209,8 +217,7 @@ export class WalletSDKUtilitiesPlugin extends SDKPlugin {
                 !contract.synchronizerId ||
                 !contract.contractId ||
                 !contract.templateId ||
-                !payload ||
-                !this.matchesPreapproval(payload, args)
+                !payload
             ) {
                 return []
             }
@@ -225,19 +232,23 @@ export class WalletSDKUtilitiesPlugin extends SDKPlugin {
             ]
         })
     }
-
-    private matchesPreapproval(
-        payload: TransferPreapproval,
-        args: FetchPreapprovalArgs
-    ): boolean {
-        return (
-            payload.receiver === args.receiver &&
-            payload.operator === args.operator &&
-            payload.instrumentAdmin === args.instrumentAdmin &&
-            (payload.instrumentAllowances.length === 0 ||
-                payload.instrumentAllowances.some(
-                    ({ id }) => id === args.instrumentId
-                ))
-        )
-    }
 }
+
+/** Returns the preapproval for an operator and instrument, or null. */
+export const findPreapproval = (
+    preapprovals: readonly TransferPreapprovalStatus[],
+    args: FetchPreapprovalArgs
+): TransferPreapprovalStatus | null =>
+    preapprovals.find(({ payload }) => matchesPreapproval(payload, args)) ??
+    null
+
+/** Does this preapproval cover the instrument? No allowances means all. */
+const matchesPreapproval = (
+    payload: TransferPreapproval,
+    args: FetchPreapprovalArgs
+): boolean =>
+    payload.receiver === args.receiver &&
+    payload.operator === args.operator &&
+    payload.instrumentAdmin === args.instrumentAdmin &&
+    (payload.instrumentAllowances.length === 0 ||
+        payload.instrumentAllowances.some(({ id }) => id === args.instrumentId))


### PR DESCRIPTION
Closes #2062.

The "Pre-approved Assets" table in Settings ran one ledger read per row. Those
reads were identical: reading utility preapprovals is a full scan of the party's
contracts, and the scan takes the party and nothing else, so every row scanned
the same thing and kept the one contract it cared about. Amulet rows repeated a
Scan Proxy lookup for the same reason. And the app refetches every 5 seconds, so
a table of N tokens meant N scans every 5 seconds for as long as it was open.

Now both reads are keyed by party and rows find themselves in the result. Two
reads instead of N. The operator party of each registry keeps its own query, so
a registry that is down only breaks its own rows.

Two things change for the user:

- If the ledger read fails, every utility row shows "Status unavailable" at
  once. They all ran that same read before, so they would have failed together
  anyway.
- Retry on one row refetches the shared read, so it retries the others too.

Two commits: the first exposes the read and the filter in the plugin, with no
change in behaviour. The second collapses the queries.

contributed by [bootnode.dev](http://bootnode.dev/)
