### PR TITLE
feat: default wallet picker to in-page modal

### DIFF
--- a/core/wallet-test-utils/src/wallet-gateway.ts
+++ b/core/wallet-test-utils/src/wallet-gateway.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, Locator, Page, test } from '@playwright/test'
-import { openWalletPicker } from './wallet-picker.js'
+import {
+    openWalletPicker,
+    WALLET_PICKER_MODAL_HOST,
+    walletPickerModalRowByTitle,
+    type WalletPickerSurface,
+} from './wallet-picker.js'
 
 export interface NetworkFormInput {
     id: string
@@ -121,14 +126,13 @@ export class WalletGateway {
                 'the dApp should offer a way to connect a wallet'
             ).toBeVisible()
 
-            const pickerPopup = await openWalletPicker(
-                dapp.dappPage,
-                connectButton
+            const picker = await openWalletPicker(dapp.dappPage, connectButton)
+
+            await this.selectFromWalletPicker(picker, args.customURL)
+
+            const popup = await this.waitForConnectFormPopup(
+                picker.kind === 'popup' ? picker.page : undefined
             )
-
-            await this.selectFromWalletPicker(pickerPopup, args.customURL)
-
-            const popup = await this.waitForConnectFormPopup(pickerPopup)
             const selectNetwork = popup.getByLabel('Select a network')
             await expect(
                 selectNetwork,
@@ -482,23 +486,46 @@ export class WalletGateway {
     }
 
     private async selectFromWalletPicker(
-        popup: Page,
+        picker: WalletPickerSurface,
         customURL?: string
     ): Promise<void> {
-        if (customURL !== undefined) {
-            const customUrlInput = popup.locator('.custom-url-input')
-            await customUrlInput.waitFor({ state: 'visible', timeout: 3000 })
-            await customUrlInput.fill(customURL)
-            await popup.locator('.btn-add').click()
+        const { page, kind } = picker
+
+        if (kind === 'modal') {
+            if (customURL !== undefined) {
+                await walletPickerModalRowByTitle(page, 'Remote Wallet').click()
+                const host = page.locator(WALLET_PICKER_MODAL_HOST)
+                const urlInput = host.getByLabel('Remote Wallet URL')
+                await urlInput.waitFor({ state: 'visible', timeout: 5_000 })
+                await urlInput.fill(customURL)
+                await host.locator('.gateway-connect-button').click()
+                return
+            }
+
+            const firstWallet = page
+                .locator(WALLET_PICKER_MODAL_HOST)
+                .getByRole('button')
+                .filter({ hasNotText: /^Remote Wallet/ })
+                .first()
+            await firstWallet.waitFor({ state: 'visible', timeout: 5_000 })
+            await firstWallet.click()
             return
         }
 
-        const walletCard = popup.locator('.wallet-card').first()
+        if (customURL !== undefined) {
+            const customUrlInput = page.locator('.custom-url-input')
+            await customUrlInput.waitFor({ state: 'visible', timeout: 3000 })
+            await customUrlInput.fill(customURL)
+            await page.locator('.btn-add').click()
+            return
+        }
+
+        const walletCard = page.locator('.wallet-card').first()
         await walletCard.waitFor({ state: 'visible', timeout: 3000 })
         await walletCard.click()
     }
 
-    private async waitForConnectFormPopup(initialPopup: Page): Promise<Page> {
+    private async waitForConnectFormPopup(initialPopup?: Page): Promise<Page> {
         const hasConnectForm = async (page: Page): Promise<boolean> => {
             try {
                 await page
@@ -518,13 +545,10 @@ export class WalletGateway {
             }
         }
 
-        // Pre-fix behavior: picker page itself transitions to connect form.
-        if (await hasConnectForm(initialPopup)) {
+        if (initialPopup && (await hasConnectForm(initialPopup))) {
             return initialPopup
         }
 
-        // New behavior: picker may close and the wallet connect form appears in
-        // a fresh popup. Poll the tracked popup first to avoid races.
         for (let i = 0; i < 20; i++) {
             const popup = this._popup
             if (popup && !popup.isClosed() && (await hasConnectForm(popup))) {

--- a/core/wallet-test-utils/src/wallet-picker.ts
+++ b/core/wallet-test-utils/src/wallet-picker.ts
@@ -3,11 +3,66 @@
 
 import type { Locator, Page } from '@playwright/test'
 
+export const WALLET_PICKER_MODAL_HOST = '[data-swk-wallet-picker-modal]'
+
+export type WalletPickerSurface = {
+    kind: 'modal' | 'popup'
+    page: Page
+    dappPage: Page
+}
+
 export async function openWalletPicker(
     dappPage: Page,
     connectButton: Locator
-): Promise<Page> {
-    const pickerPopup = dappPage.waitForEvent('popup')
+): Promise<WalletPickerSurface> {
+    const modalHost = dappPage.locator(WALLET_PICKER_MODAL_HOST)
+
+    const popupRace = dappPage
+        .waitForEvent('popup', { timeout: 15_000 })
+        .then((page): WalletPickerSurface => ({
+            kind: 'popup',
+            page,
+            dappPage,
+        }))
+        .catch(() => null)
+
+    const modalRace = modalHost
+        .waitFor({ state: 'attached', timeout: 15_000 })
+        .then((): WalletPickerSurface => ({
+            kind: 'modal',
+            page: dappPage,
+            dappPage,
+        }))
+        .catch(() => null)
+
     await connectButton.click()
-    return pickerPopup
+
+    const surface = await Promise.race([popupRace, modalRace])
+    if (!surface) {
+        throw new Error(
+            'wallet picker did not open as an in-page modal or a popup window'
+        )
+    }
+
+    if (surface.kind === 'modal') {
+        await modalHost
+            .locator('[role="dialog"]')
+            .waitFor({ state: 'visible', timeout: 5_000 })
+    }
+
+    return surface
+}
+
+export function walletPickerModalHost(dappPage: Page): Locator {
+    return dappPage.locator(WALLET_PICKER_MODAL_HOST)
+}
+
+export function walletPickerModalRowByTitle(
+    dappPage: Page,
+    title: string
+): Locator {
+    const escaped = title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    return walletPickerModalHost(dappPage).getByRole('button', {
+        name: new RegExp(`^${escaped}(\\s+${escaped})?$`),
+    })
 }

--- a/core/wallet-ui-components/src/index.ts
+++ b/core/wallet-ui-components/src/index.ts
@@ -32,6 +32,7 @@ export * from './components/transaction-card.js'
 export * from './components/transaction-detail.js'
 
 export * from './windows/wallet-picker.js'
+export * from './windows/wallet-picker-modal.js'
 export * from './windows/popup.js'
 
 export * from './handle-errors.js'

--- a/core/wallet-ui-components/src/styles/modal.ts
+++ b/core/wallet-ui-components/src/styles/modal.ts
@@ -41,3 +41,704 @@ export const modalStyles = css`
         }
     }
 `
+
+const LIGHT_TOKENS = `
+    --accent: #111111;
+    --accent-hover: #000000;
+    --accent-contrast: #ffffff;
+    --accent-soft: rgba(17, 17, 17, 0.06);
+    --border: #ececf3;
+    --border-hover: #d3d3e0;
+    --surface: #ffffff;
+    --surface-2: #f4f4f7;
+    --surface-hover: #ebebf0;
+    --text: #373737;
+    --text-muted: #6b7280;
+    --icon-muted: #999999;
+    --scrollbar: #d4d4dc;
+    --success: #4e9e73;
+    --success-soft: rgba(78, 158, 115, 0.14);
+    --danger: #dc2626;
+    --danger-text: #b91c1c;
+    --danger-soft: rgba(220, 38, 38, 0.08);
+    --danger-soft-hover: rgba(220, 38, 38, 0.1);
+    --backdrop: rgba(71, 88, 107, 0.24);
+    --fade-shadow: rgba(15, 23, 42, 0.18);
+    --shadow-modal:
+        0 12px 32px -18px rgba(15, 23, 42, 0.12),
+        0 2px 8px -6px rgba(15, 23, 42, 0.06);
+`
+
+const DARK_TOKENS = `
+    --accent: #f4f4f6;
+    --accent-hover: #e2e2e6;
+    --accent-contrast: #16171b;
+    --accent-soft: rgba(255, 255, 255, 0.08);
+    --border: #2b2d34;
+    --border-hover: #3b3e47;
+    --surface: #17181c;
+    --surface-2: #202228;
+    --surface-hover: #2a2c33;
+    --text: #e7e7ea;
+    --text-muted: #9aa0aa;
+    --icon-muted: #8a8f99;
+    --scrollbar: #3b3e47;
+    --success: #6ac394;
+    --success-soft: rgba(106, 195, 148, 0.16);
+    --danger: #f26d6d;
+    --danger-text: #f4a3a3;
+    --danger-soft: rgba(242, 109, 109, 0.12);
+    --danger-soft-hover: rgba(242, 109, 109, 0.16);
+    --backdrop: rgba(0, 0, 0, 0.5);
+    --fade-shadow: rgba(0, 0, 0, 0.5);
+    --shadow-modal:
+        0 12px 32px -18px rgba(0, 0, 0, 0.4),
+        0 2px 8px -6px rgba(0, 0, 0, 0.24);
+`
+
+export const walletPickerModalCss = `
+:host {
+    all: initial;
+}
+
+.discovery-modal-backdrop {
+${LIGHT_TOKENS}
+    position: fixed;
+    inset: 0;
+    background: var(--backdrop);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    z-index: 2147483000;
+    animation: swkFadeIn 0.2s ease-out;
+    font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+        sans-serif;
+}
+
+@keyframes swkFadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.discovery-modal-content {
+    position: relative;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    box-shadow: var(--shadow-modal);
+    width: min(87.4vw, 342px);
+    overflow: hidden;
+    animation: swkSlideUp 0.28s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.discovery-modal-inner {
+    width: min(87.4vw, 342px);
+    max-height: min(86vh, 640px);
+    display: flex;
+    flex-direction: column;
+}
+
+@keyframes swkSlideUp {
+    from { transform: translateY(16px) scale(0.98); opacity: 0; }
+    to { transform: translateY(0) scale(1); opacity: 1; }
+}
+
+.discovery-modal-content button {
+    box-sizing: border-box;
+    font-family: inherit;
+}
+
+.discovery-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 24px 20px 16px;
+}
+
+.discovery-modal-heading {
+    flex: 1;
+    min-width: 0;
+    text-align: left;
+}
+
+.discovery-modal-heading h2 {
+    margin: 0;
+    font-size: 17px;
+    line-height: 32px;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.discovery-modal-back,
+.discovery-modal-close {
+    flex-shrink: 0;
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    color: var(--icon-muted);
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    transition:
+        background 0.15s ease,
+        color 0.15s ease,
+        transform 0.15s ease;
+}
+
+.discovery-modal-back svg,
+.discovery-modal-close svg {
+    display: block;
+}
+
+.discovery-modal-back:hover,
+.discovery-modal-close:hover {
+    background: var(--surface-hover);
+    color: var(--text);
+}
+
+.discovery-modal-back:active,
+.discovery-modal-close:active {
+    transform: scale(0.92);
+}
+
+.discovery-modal-body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 4px 20px 10px;
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar) transparent;
+}
+
+.discovery-modal-body::-webkit-scrollbar {
+    width: 8px;
+}
+
+.discovery-modal-body::-webkit-scrollbar-thumb {
+    background: var(--scrollbar);
+    border-radius: 4px;
+    border: 2px solid var(--surface);
+}
+
+.discovery-modal-view {
+    animation: swkViewFade 0.25s ease;
+}
+
+@keyframes swkViewFade {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.discovery-modal-error {
+    margin: 0 0 12px;
+    padding: 10px 12px;
+    border-radius: 12px;
+    background: var(--danger-soft);
+    color: var(--danger-text);
+    font-size: 13px;
+    line-height: 1.4;
+}
+
+.wallet-picker-container {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    /* Show ~4.5 wallet rows (62px tall + 8px gap), then scroll. Only this
+       list scrolls; the header and footer stay fixed. */
+    max-height: calc(4.5 * 62px + 4 * 8px);
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar) transparent;
+    padding-right: 4px;
+    margin-right: -4px;
+}
+
+.wallet-picker-container::-webkit-scrollbar {
+    width: 8px;
+}
+
+.wallet-picker-container::-webkit-scrollbar-thumb {
+    background: var(--scrollbar);
+    border-radius: 4px;
+    border: 2px solid var(--surface);
+}
+
+/* Non-scrolling wrapper so the fade can sit at the list's viewport bottom. */
+.wallet-picker-scroll {
+    position: relative;
+}
+
+/* Fading divider pinned to the bottom of the scroll viewport to hint at more
+   content below. Purely visual; clicks pass through to the row beneath. */
+.wallet-picker-fade {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 22px;
+    z-index: 10;
+    pointer-events: none;
+    /* Inset shadow anchored to the bottom edge: reads as a shadowed border and
+       stays clipped within this overlay so it never creeps onto the row above. */
+    box-shadow: inset 0 -10px 10px -9px var(--fade-shadow);
+    transition: opacity 300ms;
+}
+
+/* Mirror of the bottom fade, anchored to the top edge (content scrolled above). */
+.wallet-picker-fade-top {
+    top: 0;
+    bottom: auto;
+    box-shadow: inset 0 10px 10px -9px var(--fade-shadow);
+}
+
+/* Hidden once the list fits or is scrolled to the bottom (no more content). */
+.wallet-picker-fade.is-hidden {
+    opacity: 0;
+}
+
+.wallet-picker-item {
+    display: flex;
+    align-items: stretch;
+    flex-shrink: 0;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    overflow: hidden;
+    transition:
+        border-color 0.15s ease,
+        background 0.15s ease,
+        box-shadow 0.15s ease,
+        transform 0.1s ease;
+}
+
+.wallet-picker-item-main {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex: 1;
+    min-width: 0;
+    padding: 14px 16px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    width: 100%;
+}
+
+.wallet-picker-item:hover {
+    background: var(--accent-soft);
+    border-color: var(--border-hover);
+}
+
+.wallet-picker-item:active {
+    transform: scale(0.985);
+}
+
+.wallet-picker-remove {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    align-self: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    margin: 0 8px 0 0;
+    border-radius: 50%;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition:
+        background 0.15s ease,
+        color 0.15s ease;
+}
+
+.wallet-picker-remove:hover {
+    background: var(--danger-soft-hover);
+    color: var(--danger);
+}
+
+.wallet-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 22.5%;
+    flex-shrink: 0;
+    background: var(--surface-2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    color: var(--text-muted);
+}
+
+.wallet-icon img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.wallet-icon-fallback {
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--accent);
+}
+
+.wallet-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.wallet-info h3 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.wallet-installed-badge {
+    flex-shrink: 0;
+    margin-left: auto;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    padding: 3px 8px;
+    border-radius: 999px;
+    color: var(--success);
+    background: var(--success-soft);
+}
+
+/* Plain text label revealed on row hover; the whole row is the install target. */
+.wallet-get-badge {
+    flex-shrink: 0;
+    margin-left: auto;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    color: var(--text-muted);
+    white-space: nowrap;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.wallet-picker-item:hover .wallet-get-badge,
+.wallet-picker-item:focus-within .wallet-get-badge {
+    opacity: 1;
+}
+
+.custom-url-input {
+    width: 100%;
+    box-sizing: border-box;
+    height: 40px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 0 12px;
+    font-size: 14px;
+    color: var(--text);
+    background: var(--surface);
+}
+
+.custom-url-input:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+    border-color: var(--accent);
+}
+
+.gateway-view {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 8px 4px 4px;
+}
+
+.gateway-help {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 400;
+    color: var(--text-muted);
+    text-align: left;
+}
+
+.gateway-connect-button {
+    width: 100%;
+    height: 44px;
+    border: 1px solid var(--accent);
+    border-radius: 12px;
+    padding: 0 14px;
+    background: var(--accent);
+    color: var(--accent-contrast);
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition:
+        background 0.15s ease,
+        border-color 0.15s ease,
+        opacity 0.15s ease;
+}
+
+.gateway-connect-button:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+}
+
+.gateway-connect-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+}
+
+.discovery-modal-footer {
+    padding: 10px 20px 16px;
+    background: var(--surface);
+    text-align: center;
+}
+
+.discovery-modal-no-wallet {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 14px;
+    line-height: 1;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-decoration: none;
+    transition: color 0.15s ease;
+}
+
+.discovery-modal-no-wallet svg {
+    display: block;
+    flex-shrink: 0;
+}
+
+.discovery-modal-no-wallet-label {
+    display: block;
+    transform: translateY(1px);
+}
+
+.discovery-modal-no-wallet:hover {
+    color: var(--accent);
+    text-decoration: underline;
+}
+
+.walletconnect-view {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 24px 20px 8px;
+    gap: 8px;
+}
+
+.connecting-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 18px;
+    padding: 28px 16px 16px;
+}
+
+.connecting-spinner-ring {
+    position: relative;
+    width: 92px;
+    height: 92px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.connecting-spinner-ring::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 26px;
+    padding: 3px;
+    background: conic-gradient(
+        from var(--swk-spinner-angle),
+        var(--accent) 0deg,
+        var(--accent-soft) 70deg,
+        var(--accent-soft) 360deg
+    );
+    -webkit-mask:
+        linear-gradient(#fff 0 0) content-box,
+        linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask:
+        linear-gradient(#fff 0 0) content-box,
+        linear-gradient(#fff 0 0);
+    mask-composite: exclude;
+    animation: swkSpinnerAngle 0.9s linear infinite;
+}
+
+@keyframes swkSpinnerAngle {
+    to { --swk-spinner-angle: 360deg; }
+}
+
+.connecting-avatar {
+    width: 72px;
+    height: 72px;
+    border-radius: 22.5%;
+    overflow: hidden;
+    background: var(--surface-2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.connecting-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.connecting-avatar-fallback {
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--accent);
+}
+
+.walletconnect-qr {
+    width: 220px;
+    height: 220px;
+    border-radius: 16px;
+    display: block;
+    margin: 0 auto 8px;
+    padding: 12px;
+    box-sizing: border-box;
+    background: #ffffff;
+    border: 1px solid var(--border);
+    box-shadow: 0 8px 24px -12px rgba(15, 23, 42, 0.25);
+}
+
+.walletconnect-qr-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--surface-2);
+}
+
+.walletconnect-title {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.walletconnect-divider {
+    position: relative;
+    width: 100%;
+    height: 1px;
+    background: var(--border);
+    margin: 16px 0 12px;
+}
+
+.walletconnect-divider-label {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    padding: 0 10px;
+    background: var(--surface);
+    color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+}
+
+.walletconnect-copy-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: 100%;
+    margin-top: 6px;
+    padding: 12px 20px;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: var(--text);
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+    transition:
+        background 0.15s ease,
+        border-color 0.15s ease,
+        transform 0.1s ease;
+}
+
+.walletconnect-copy-button svg {
+    display: block;
+}
+
+.walletconnect-copy-button:hover:not(:disabled) {
+    background: var(--surface-hover);
+    border-color: var(--border-hover);
+}
+
+.walletconnect-copy-button:disabled {
+    opacity: 0.5;
+    cursor: progress;
+}
+
+.walletconnect-spinner {
+    width: 36px;
+    height: 36px;
+    border: 3px solid var(--border);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: swkWcSpin 0.8s linear infinite;
+}
+
+.walletconnect-help {
+    margin: 0;
+    font-size: 14px;
+    color: var(--text-muted);
+}
+
+@keyframes swkWcSpin {
+    to { transform: rotate(360deg); }
+}
+
+@media (prefers-color-scheme: dark) {
+    .discovery-modal-backdrop {
+${DARK_TOKENS}
+    }
+}
+
+/* Explicit theme override (wins over the OS setting via prefers-color-scheme). */
+:host([data-swk-theme='dark']) .discovery-modal-backdrop {
+${DARK_TOKENS}
+}
+
+:host([data-swk-theme='light']) .discovery-modal-backdrop {
+${LIGHT_TOKENS}
+}
+
+@media (max-width: 600px) {
+    .discovery-modal-backdrop {
+        align-items: flex-end;
+        padding: 0;
+    }
+
+    .discovery-modal-content {
+        width: 100vw;
+        max-height: 88vh;
+        border-radius: 20px 20px 0 0;
+    }
+
+    .discovery-modal-inner {
+        width: 100vw;
+    }
+}
+`

--- a/core/wallet-ui-components/src/windows/wallet-picker-modal.test.ts
+++ b/core/wallet-ui-components/src/windows/wallet-picker-modal.test.ts
@@ -1,0 +1,735 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { WalletPickerEntry } from '@canton-network/core-types'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { makeWalletPickerEntry } from '../components/fixtures.js'
+import {
+    notifyWalletPickerModalConnected,
+    notifyWalletPickerModalError,
+    pickWalletModal,
+    setWalletPickerModalTheme,
+    setWalletPickerModalWalletConnectUri,
+    waitForWalletPickerModalBack,
+    waitForWalletPickerModalRetrySelection,
+} from './wallet-picker-modal.js'
+
+const RECENT_KEY = 'splice_wallet_picker_recent'
+const SUGGESTED_KEY = 'splice_wallet_picker_suggested_entries'
+
+function modalHost(): HTMLElement {
+    const host = document.querySelector(
+        '[data-swk-wallet-picker-modal]'
+    ) as HTMLElement | null
+    if (!host) throw new Error('wallet picker modal host not found')
+    return host
+}
+
+function shadow(): ShadowRoot {
+    const root = modalHost().shadowRoot
+    if (!root) throw new Error('wallet picker modal shadow root missing')
+    return root
+}
+
+function titleText(): string {
+    return shadow().querySelector('h2')?.textContent ?? ''
+}
+
+function walletTitles(): string[] {
+    return Array.from(
+        shadow().querySelectorAll('.wallet-picker-item-main h3')
+    ).map((node) => node.textContent ?? '')
+}
+
+function clickWalletByExactName(name: string): void {
+    const buttons = Array.from(
+        shadow().querySelectorAll<HTMLButtonElement>('.wallet-picker-item-main')
+    )
+    const match = buttons.find(
+        (btn) => btn.querySelector('h3')?.textContent === name
+    )
+    if (!match) throw new Error(`wallet button not found: ${name}`)
+    match.click()
+}
+
+function clickClose(): void {
+    const close = shadow().querySelector<HTMLButtonElement>(
+        '[aria-label="Close modal"]'
+    )
+    if (!close) throw new Error('close button not found')
+    close.click()
+}
+
+function clickBack(): void {
+    const back = shadow().querySelector<HTMLButtonElement>(
+        '[aria-label="Go back"]'
+    )
+    if (!back) throw new Error('back button not found')
+    back.click()
+}
+
+function clickBackdrop(): void {
+    const backdrop = shadow().querySelector<HTMLElement>(
+        '.discovery-modal-backdrop'
+    )
+    if (!backdrop) throw new Error('backdrop not found')
+    backdrop.click()
+}
+
+function forceRemoveHosts(): void {
+    document
+        .querySelectorAll('[data-swk-wallet-picker-modal]')
+        .forEach((node) => node.remove())
+}
+
+async function settleOrTimeout<T>(
+    promise: Promise<T>,
+    ms = 50
+): Promise<'settled' | 'timeout'> {
+    return Promise.race([
+        promise.then(
+            () => 'settled' as const,
+            () => 'settled' as const
+        ),
+        new Promise<'timeout'>((resolve) =>
+            setTimeout(() => resolve('timeout'), ms)
+        ),
+    ])
+}
+
+describe('windows/wallet-picker-modal', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        setWalletPickerModalTheme('auto')
+        forceRemoveHosts()
+    })
+
+    afterEach(() => {
+        // Teardown only — do not fake a successful connect.
+        forceRemoveHosts()
+        setWalletPickerModalTheme('auto')
+        localStorage.clear()
+    })
+
+    it('pickWalletModal mounts an in-page dialog and lists entries', async () => {
+        const entries: WalletPickerEntry[] = [
+            makeWalletPickerEntry({
+                providerId: 'ext:alpha',
+                name: 'Alpha Wallet',
+                type: 'browser',
+            }),
+        ]
+
+        const pickPromise = pickWalletModal(entries)
+
+        const host = modalHost()
+        expect(host.isConnected).toBe(true)
+        expect(host.shadowRoot).not.toBeNull()
+
+        const dialog = shadow().querySelector('[role="dialog"]')
+        expect(dialog?.getAttribute('aria-modal')).toBe('true')
+        expect(titleText()).toBe('Connect Wallet')
+        expect(walletTitles()).toContain('Alpha Wallet')
+        expect(walletTitles()).toContain('Remote Wallet')
+        expect(
+            shadow().querySelector('.wallet-installed-badge')?.textContent
+        ).toBe('Installed')
+
+        clickClose()
+        await expect(pickPromise).rejects.toThrow(
+            'User closed the wallet picker'
+        )
+        expect(
+            document.querySelector('[data-swk-wallet-picker-modal]')
+        ).toBeNull()
+    })
+
+    it('pickWalletModal resolves when a wallet is selected', async () => {
+        const entries: WalletPickerEntry[] = [
+            makeWalletPickerEntry({
+                providerId: 'ext:selected',
+                name: 'Selected Wallet',
+                type: 'browser',
+            }),
+        ]
+
+        const pickPromise = pickWalletModal(entries)
+        clickWalletByExactName('Selected Wallet')
+
+        await expect(pickPromise).resolves.toMatchObject({
+            providerId: 'ext:selected',
+            name: 'Selected Wallet',
+            type: 'browser',
+        })
+
+        expect(titleText()).toBe('Connecting...')
+        expect(
+            document.querySelector('[data-swk-wallet-picker-modal]')
+        ).not.toBeNull()
+
+        notifyWalletPickerModalConnected()
+        expect(
+            document.querySelector('[data-swk-wallet-picker-modal]')
+        ).toBeNull()
+    })
+
+    it('pickWalletModal resolves remote entry shape including url flags', async () => {
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'remote:https://gw.example/',
+                name: 'Gateway',
+                type: 'remote',
+                url: 'https://gw.example/',
+                reuseGlobalWalletPopup: true,
+            }),
+        ])
+        clickWalletByExactName('Gateway')
+
+        await expect(pickPromise).resolves.toEqual({
+            providerId: 'remote:https://gw.example/',
+            name: 'Gateway',
+            type: 'remote',
+            url: 'https://gw.example/',
+            reuseGlobalWalletPopup: true,
+        })
+
+        notifyWalletPickerModalConnected()
+    })
+
+    it('pickWalletModal rejects when closed before selection', async () => {
+        const pickPromise = pickWalletModal([makeWalletPickerEntry()])
+
+        clickClose()
+
+        await expect(pickPromise).rejects.toThrow(
+            'User closed the wallet picker'
+        )
+        expect(
+            document.querySelector('[data-swk-wallet-picker-modal]')
+        ).toBeNull()
+    })
+
+    it('backdrop click rejects like close; content click does not', async () => {
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:backdrop',
+                name: 'Backdrop Wallet',
+                type: 'browser',
+            }),
+        ])
+
+        shadow().querySelector<HTMLElement>('[role="dialog"]')?.click()
+        expect(await settleOrTimeout(pickPromise, 30)).toBe('timeout')
+        expect(modalHost().isConnected).toBe(true)
+
+        clickBackdrop()
+        await expect(pickPromise).rejects.toThrow(
+            'User closed the wallet picker'
+        )
+        expect(
+            document.querySelector('[data-swk-wallet-picker-modal]')
+        ).toBeNull()
+    })
+
+    it('re-opening pickWalletModal replaces the host and rejects the prior pick', async () => {
+        const first = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:first',
+                name: 'First',
+                type: 'browser',
+            }),
+        ])
+        const second = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:second',
+                name: 'Second',
+                type: 'browser',
+            }),
+        ])
+
+        expect(
+            document.querySelectorAll('[data-swk-wallet-picker-modal]')
+        ).toHaveLength(1)
+        expect(walletTitles()).toContain('Second')
+        expect(walletTitles()).not.toContain('First')
+
+        await expect(first).rejects.toThrow('User closed the wallet picker')
+
+        clickWalletByExactName('Second')
+        await expect(second).resolves.toMatchObject({
+            providerId: 'ext:second',
+            name: 'Second',
+        })
+        notifyWalletPickerModalConnected()
+    })
+
+    it('notifyWalletPickerModalConnected removes the modal', async () => {
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:ok',
+                name: 'OK Wallet',
+                type: 'browser',
+            }),
+        ])
+        clickWalletByExactName('OK Wallet')
+        await pickPromise
+
+        expect(
+            document.querySelector('[data-swk-wallet-picker-modal]')
+        ).not.toBeNull()
+
+        notifyWalletPickerModalConnected()
+
+        expect(
+            document.querySelector('[data-swk-wallet-picker-modal]')
+        ).toBeNull()
+    })
+
+    it('notifyWalletPickerModalError returns to the list with an alert', async () => {
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:fail',
+                name: 'Fail Wallet',
+                type: 'browser',
+            }),
+        ])
+        clickWalletByExactName('Fail Wallet')
+        await pickPromise
+
+        notifyWalletPickerModalError('Something went wrong')
+
+        expect(titleText()).toBe('Connect Wallet')
+        const alert = shadow().querySelector(
+            '.discovery-modal-error[role="alert"]'
+        )
+        expect(alert?.textContent).toBe('Something went wrong')
+
+        clickClose()
+        // No pending selection waiter after error — close only destroys.
+        expect(
+            document.querySelector('[data-swk-wallet-picker-modal]')
+        ).toBeNull()
+    })
+
+    it('error while WalletConnect connecting clears QR and returns to list', async () => {
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'walletconnect',
+                name: 'WalletConnect',
+                type: 'browser',
+            }),
+        ])
+        clickWalletByExactName('WalletConnect')
+        await pickPromise
+
+        setWalletPickerModalWalletConnectUri(
+            'wc:test-uri',
+            'data:image/png;base64,abc'
+        )
+        expect(
+            shadow().querySelector('img[alt="WalletConnect QR code"]')
+        ).not.toBeNull()
+
+        notifyWalletPickerModalError('WC failed')
+
+        expect(titleText()).toBe('Connect Wallet')
+        expect(
+            shadow().querySelector('img[alt="WalletConnect QR code"]')
+        ).toBeNull()
+        expect(
+            shadow().querySelector('.discovery-modal-error[role="alert"]')
+                ?.textContent
+        ).toBe('WC failed')
+
+        clickWalletByExactName('WalletConnect')
+        expect(titleText()).toBe('Scan with your phone')
+        expect(
+            shadow().querySelector('.walletconnect-qr-placeholder')
+        ).not.toBeNull()
+
+        notifyWalletPickerModalConnected()
+    })
+
+    it('waitForWalletPickerModalRetrySelection resolves on a new selection', async () => {
+        const first = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:first',
+                name: 'First',
+                type: 'browser',
+            }),
+            makeWalletPickerEntry({
+                providerId: 'ext:retry',
+                name: 'Retry Wallet',
+                type: 'browser',
+            }),
+        ])
+        clickWalletByExactName('First')
+        await first
+
+        notifyWalletPickerModalError('try again')
+
+        const retryPromise = waitForWalletPickerModalRetrySelection()
+        clickWalletByExactName('Retry Wallet')
+
+        await expect(retryPromise).resolves.toMatchObject({
+            providerId: 'ext:retry',
+            name: 'Retry Wallet',
+            type: 'browser',
+        })
+        expect(titleText()).toBe('Connecting...')
+        expect(shadow().querySelector('[role="alert"]')).toBeNull()
+
+        notifyWalletPickerModalConnected()
+    })
+
+    it('waitForWalletPickerModalRetrySelection rejects when closed during retry', async () => {
+        const first = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:first',
+                name: 'First',
+                type: 'browser',
+            }),
+        ])
+        clickWalletByExactName('First')
+        await first
+        notifyWalletPickerModalError('try again')
+
+        const retryPromise = waitForWalletPickerModalRetrySelection()
+        clickClose()
+
+        await expect(retryPromise).rejects.toThrow(
+            'User closed the wallet picker'
+        )
+        expect(
+            document.querySelector('[data-swk-wallet-picker-modal]')
+        ).toBeNull()
+    })
+
+    it('waitForWalletPickerModalRetrySelection throws when no modal is open', async () => {
+        await expect(waitForWalletPickerModalRetrySelection()).rejects.toThrow(
+            'Wallet picker is not open'
+        )
+    })
+
+    it('waitForWalletPickerModalBack resolves when back is clicked while connecting', async () => {
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:back',
+                name: 'Back Wallet',
+                type: 'browser',
+            }),
+        ])
+        clickWalletByExactName('Back Wallet')
+        await pickPromise
+
+        const backPromise = waitForWalletPickerModalBack()
+        clickBack()
+
+        await expect(backPromise).resolves.toBeUndefined()
+        expect(titleText()).toBe('Connect Wallet')
+
+        clickClose()
+    })
+
+    it('back before waitForWalletPickerModalBack is latched for the next await', async () => {
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:latch',
+                name: 'Latch Wallet',
+                type: 'browser',
+            }),
+        ])
+        clickWalletByExactName('Latch Wallet')
+        await pickPromise
+
+        clickBack()
+        expect(titleText()).toBe('Connect Wallet')
+
+        await expect(waitForWalletPickerModalBack()).resolves.toBeUndefined()
+
+        clickClose()
+    })
+
+    it('close while connecting settles waitForWalletPickerModalBack', async () => {
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:close-connect',
+                name: 'Close Connect',
+                type: 'browser',
+            }),
+        ])
+        clickWalletByExactName('Close Connect')
+        await pickPromise
+
+        const backPromise = waitForWalletPickerModalBack()
+        clickClose()
+
+        await expect(backPromise).resolves.toBeUndefined()
+        expect(
+            document.querySelector('[data-swk-wallet-picker-modal]')
+        ).toBeNull()
+    })
+
+    it('waitForWalletPickerModalBack never settles when no modal is open', async () => {
+        const backPromise = waitForWalletPickerModalBack()
+        expect(await settleOrTimeout(backPromise, 50)).toBe('timeout')
+    })
+
+    it('setWalletPickerModalTheme applies data-swk-theme on the host', async () => {
+        setWalletPickerModalTheme('dark')
+        const pickPromise = pickWalletModal([makeWalletPickerEntry()])
+
+        expect(modalHost().getAttribute('data-swk-theme')).toBe('dark')
+
+        setWalletPickerModalTheme('light')
+        expect(modalHost().getAttribute('data-swk-theme')).toBe('light')
+
+        setWalletPickerModalTheme('auto')
+        expect(modalHost().hasAttribute('data-swk-theme')).toBe(false)
+
+        clickClose()
+        await expect(pickPromise).rejects.toThrow(
+            'User closed the wallet picker'
+        )
+    })
+
+    it('WalletConnect connecting shows placeholder until URI/QR are set', async () => {
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'walletconnect',
+                name: 'WalletConnect',
+                type: 'browser',
+            }),
+        ])
+        clickWalletByExactName('WalletConnect')
+        await pickPromise
+
+        expect(titleText()).toBe('Scan with your phone')
+        expect(
+            shadow().querySelector('.walletconnect-qr-placeholder')
+        ).not.toBeNull()
+        const copy = shadow().querySelector<HTMLButtonElement>(
+            '.walletconnect-copy-button'
+        )
+        expect(copy?.disabled).toBe(true)
+
+        setWalletPickerModalWalletConnectUri('wc:test-uri')
+        expect(
+            shadow().querySelector('.walletconnect-qr-placeholder')
+        ).not.toBeNull()
+        expect(
+            shadow().querySelector('img[alt="WalletConnect QR code"]')
+        ).toBeNull()
+        expect(
+            shadow().querySelector<HTMLButtonElement>(
+                '.walletconnect-copy-button'
+            )?.disabled
+        ).toBe(false)
+
+        setWalletPickerModalWalletConnectUri(
+            'wc:test-uri',
+            'data:image/png;base64,abc'
+        )
+        const qr = shadow().querySelector<HTMLImageElement>(
+            'img[alt="WalletConnect QR code"]'
+        )
+        expect(qr?.getAttribute('src')).toBe('data:image/png;base64,abc')
+
+        notifyWalletPickerModalConnected()
+    })
+
+    it('custom Remote Wallet gateway normalizes URL and resolves selection', async () => {
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:other',
+                name: 'Other',
+                type: 'browser',
+            }),
+        ])
+
+        clickWalletByExactName('Remote Wallet')
+        expect(titleText()).toBe('Remote Wallet')
+
+        const input = shadow().querySelector<HTMLInputElement>(
+            'input[aria-label="Remote Wallet URL"]'
+        )
+        const connect = shadow().querySelector<HTMLButtonElement>(
+            '.gateway-connect-button'
+        )
+        expect(input).not.toBeNull()
+        expect(connect?.disabled).toBe(true)
+
+        input!.value = 'wallet.example.com'
+        input!.dispatchEvent(new Event('input', { bubbles: true }))
+        expect(connect?.disabled).toBe(false)
+
+        connect!.click()
+
+        const normalized = 'https://wallet.example.com/'
+        await expect(pickPromise).resolves.toEqual({
+            providerId: `custom:remote:${encodeURIComponent(normalized)}`,
+            name: 'wallet.example.com',
+            type: 'remote',
+            url: normalized,
+            reuseGlobalWalletPopup: false,
+        })
+        expect(titleText()).toBe('Connecting...')
+
+        notifyWalletPickerModalConnected()
+    })
+
+    it('gateway back returns to list without settling the pick promise', async () => {
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:gw-back',
+                name: 'GW Back',
+                type: 'browser',
+            }),
+        ])
+
+        clickWalletByExactName('Remote Wallet')
+        clickBack()
+        expect(titleText()).toBe('Connect Wallet')
+        expect(await settleOrTimeout(pickPromise, 30)).toBe('timeout')
+
+        clickClose()
+        await expect(pickPromise).rejects.toThrow(
+            'User closed the wallet picker'
+        )
+    })
+
+    it('loads recent gateways from localStorage and can remove them', async () => {
+        localStorage.setItem(
+            RECENT_KEY,
+            JSON.stringify([
+                { name: 'Recent GW', rpcUrl: 'https://recent.example/' },
+            ])
+        )
+
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:browser',
+                name: 'Browser Wallet',
+                type: 'browser',
+            }),
+        ])
+
+        const titles = walletTitles()
+        expect(titles[0]).toBe('Recent GW')
+        expect(titles).toContain('Browser Wallet')
+
+        const remove = shadow().querySelector<HTMLButtonElement>(
+            '[aria-label="Remove Recent GW"]'
+        )
+        expect(remove).not.toBeNull()
+        remove!.click()
+
+        expect(walletTitles()).not.toContain('Recent GW')
+        expect(localStorage.getItem(RECENT_KEY)).toBeNull()
+        expect(await settleOrTimeout(pickPromise, 30)).toBe('timeout')
+
+        clickClose()
+        await expect(pickPromise).rejects.toThrow(
+            'User closed the wallet picker'
+        )
+    })
+
+    it('dedupes recent gateways that already exist as remote entries', async () => {
+        localStorage.setItem(
+            RECENT_KEY,
+            JSON.stringify([
+                { name: 'Dup Recent', rpcUrl: 'https://gw.example/' },
+            ])
+        )
+
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'remote:https://gw.example/',
+                name: 'Registered GW',
+                type: 'remote',
+                url: 'https://gw.example/',
+            }),
+        ])
+
+        expect(walletTitles().filter((t) => t === 'Dup Recent')).toHaveLength(0)
+        expect(walletTitles()).toContain('Registered GW')
+        expect(
+            shadow().querySelector('[aria-label="Remove Dup Recent"]')
+        ).toBeNull()
+
+        clickClose()
+        await expect(pickPromise).rejects.toThrow(
+            'User closed the wallet picker'
+        )
+    })
+
+    it('renders suggested wallets that are not already detected', async () => {
+        localStorage.setItem(
+            SUGGESTED_KEY,
+            JSON.stringify([
+                {
+                    providerId: 'ext:already',
+                    name: 'Already Installed',
+                    installUrls: [
+                        {
+                            platform: 'chrome',
+                            url: 'https://example.com/already',
+                        },
+                    ],
+                },
+                {
+                    providerId: 'ext:suggested',
+                    name: 'Suggested Wallet',
+                    installUrls: [
+                        {
+                            platform: 'chrome',
+                            url: 'https://example.com/suggested',
+                        },
+                    ],
+                },
+            ])
+        )
+
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:already',
+                name: 'Already Installed',
+                type: 'browser',
+            }),
+        ])
+
+        expect(walletTitles()).toContain('Suggested Wallet')
+        expect(
+            walletTitles().filter((t) => t === 'Already Installed')
+        ).toHaveLength(1)
+        expect(
+            shadow().querySelector('.wallet-get-badge')?.textContent
+        ).toMatch(/^Get/)
+
+        clickClose()
+        await expect(pickPromise).rejects.toThrow(
+            'User closed the wallet picker'
+        )
+    })
+
+    it('survives corrupt recent/suggested localStorage', async () => {
+        localStorage.setItem(RECENT_KEY, '{')
+        localStorage.setItem(SUGGESTED_KEY, 'not-json')
+
+        const pickPromise = pickWalletModal([
+            makeWalletPickerEntry({
+                providerId: 'ext:ok',
+                name: 'OK',
+                type: 'browser',
+            }),
+        ])
+
+        expect(titleText()).toBe('Connect Wallet')
+        expect(walletTitles()).toContain('OK')
+
+        clickClose()
+        await expect(pickPromise).rejects.toThrow(
+            'User closed the wallet picker'
+        )
+    })
+})

--- a/core/wallet-ui-components/src/windows/wallet-picker-modal.ts
+++ b/core/wallet-ui-components/src/windows/wallet-picker-modal.ts
@@ -1,0 +1,940 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+    BrowserPlatform,
+    WalletPickerEntry,
+    WalletPickerResult,
+    WalletPickerSuggestedEntry,
+} from '@canton-network/core-types'
+import cantonLogo from '../../images/logos/canton-logo.png'
+import { walletPickerModalCss } from '../styles/modal.js'
+
+const RECENT_KEY = 'splice_wallet_picker_recent'
+const SUGGESTED_KEY = 'splice_wallet_picker_suggested_entries'
+
+type RecentGateway = { name: string; rpcUrl: string }
+
+/**
+ * In-page wallet picker modal.
+ *
+ * This is the framework-neutral, SDK-default counterpart to the popup-based
+ * {@link ./wallet-picker.ts | pickWallet}. Instead of opening a separate
+ * browser window, it renders a modal directly into the host page inside a
+ * Shadow DOM (so host styles cannot leak in or out).
+ *
+ * The public contract mirrors the popup module so the SDK can drive it the
+ * same way:
+ *   - {@link pickWalletModal} shows the wallet list and resolves with the
+ *     user's first selection.
+ *   - {@link notifyWalletPickerModalConnected} closes the modal on success.
+ *   - {@link notifyWalletPickerModalError} shows an error and returns to the
+ *     list so the user can retry.
+ *   - {@link waitForWalletPickerModalRetrySelection} resolves with the next
+ *     selection after an error.
+ *   - {@link setWalletPickerModalWalletConnectUri} feeds a WalletConnect
+ *     pairing URI/QR into the connecting view.
+ */
+
+const el = <K extends keyof HTMLElementTagNameMap>(
+    tag: K,
+    text = '',
+    attrs: Record<string, string> = {}
+): HTMLElementTagNameMap[K] => {
+    const node = document.createElement(tag)
+    if (text) node.textContent = text
+    for (const [k, v] of Object.entries(attrs)) node.setAttribute(k, v)
+    return node
+}
+
+const BROWSER_ICON =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>'
+
+const detectBrowserPlatform = (): BrowserPlatform | 'unsupported' => {
+    const userAgent = window.navigator.userAgent
+    if (/firefox/i.test(userAgent)) return 'firefox'
+    if (/chrome|chromium|crios/i.test(userAgent)) return 'chrome'
+    return 'unsupported'
+}
+
+// The connecting spinner animates a registered <angle> custom property so the
+// conic-gradient highlight travels around the ring. `@property` is ignored when
+// declared inside a shadow root, so it must be registered at the document level.
+let spinnerPropertyRegistered = false
+const ensureSpinnerProperty = (): void => {
+    if (spinnerPropertyRegistered) return
+    spinnerPropertyRegistered = true
+    try {
+        const cssApi = (
+            globalThis as {
+                CSS?: { registerProperty?: (definition: object) => void }
+            }
+        ).CSS
+        cssApi?.registerProperty?.({
+            name: '--swk-spinner-angle',
+            syntax: '<angle>',
+            inherits: false,
+            initialValue: '0deg',
+        })
+    } catch {
+        // Already registered (e.g. the modal was opened before) — safe to ignore.
+    }
+}
+
+class WalletPickerModalController {
+    private host: HTMLDivElement
+    private shadow: ShadowRoot
+    private backdrop: HTMLElement | null = null
+    private contentEl: HTMLElement | null = null
+    private onHeightTransitionEnd: ((e: TransitionEvent) => void) | undefined =
+        undefined
+
+    private entries: WalletPickerEntry[] = []
+    private recentGateways: RecentGateway[] = []
+    private suggested: WalletPickerSuggestedEntry[] = []
+    private readonly platform = detectBrowserPlatform()
+
+    private state: 'list' | 'gateway' | 'connecting' = 'list'
+    private errorMessage = ''
+    private selected: WalletPickerResult | null = null
+    private selectedIcon: string | null = null
+    private wcUri: string | null = null
+    private wcQrDataUrl: string | null = null
+    private copied = false
+
+    private destroyed = false
+    private pending: {
+        resolve: (v: WalletPickerResult) => void
+        reject: (e: unknown) => void
+    } | null = null
+    private backPending: { resolve: () => void } | null = null
+    private backRequested = false
+
+    constructor(entries: WalletPickerEntry[]) {
+        this.entries = entries
+        this.recentGateways = this.loadRecentGateways()
+        this.suggested = this.loadSuggested()
+
+        ensureSpinnerProperty()
+
+        this.host = document.createElement('div')
+        this.host.setAttribute('data-swk-wallet-picker-modal', '')
+        this.applyTheme(modalTheme)
+        this.shadow = this.host.attachShadow({ mode: 'open' })
+
+        const style = document.createElement('style')
+        style.textContent = walletPickerModalCss
+        this.shadow.appendChild(style)
+
+        document.body.appendChild(this.host)
+        this.render()
+    }
+
+    // ── Public flow control ────────────────────────────────
+
+    awaitSelection(): Promise<WalletPickerResult> {
+        return new Promise<WalletPickerResult>((resolve, reject) => {
+            this.pending = { resolve, reject }
+        })
+    }
+
+    /**
+     * Resolves when the user clicks "back" from the connecting view, signalling
+     * the SDK to abort the in-flight attempt and re-await a selection.
+     */
+    awaitBack(): Promise<void> {
+        if (this.backRequested) {
+            this.backRequested = false
+            return Promise.resolve()
+        }
+        return new Promise<void>((resolve) => {
+            this.backPending = { resolve }
+        })
+    }
+
+    setConnected(): void {
+        this.destroy()
+    }
+
+    setError(message: string): void {
+        this.errorMessage = message
+        this.selected = null
+        this.selectedIcon = null
+        this.wcUri = null
+        this.wcQrDataUrl = null
+        this.state = 'list'
+        this.render()
+    }
+
+    setWalletConnectUri(uri: string, qrDataUrl?: string): void {
+        this.wcUri = uri
+        this.wcQrDataUrl = qrDataUrl ?? null
+        if (this.state === 'connecting' && this.isWalletConnect()) {
+            this.render()
+        }
+    }
+
+    isActive(): boolean {
+        return !this.destroyed
+    }
+
+    /** Forces the color scheme on the host element (`'auto'` clears the override). */
+    applyTheme(theme: WalletPickerModalTheme): void {
+        if (theme === 'auto') {
+            this.host.removeAttribute('data-swk-theme')
+        } else {
+            this.host.setAttribute('data-swk-theme', theme)
+        }
+    }
+
+    destroy(): void {
+        if (this.destroyed) return
+        this.destroyed = true
+
+        // Re-open / teardown must not leave SDK waiters hanging forever.
+        const pending = this.pending
+        this.pending = null
+        pending?.reject(new Error('User closed the wallet picker'))
+
+        if (this.backPending) {
+            const back = this.backPending
+            this.backPending = null
+            back.resolve()
+        }
+
+        this.host.remove()
+    }
+
+    // ── Storage helpers ────────────────────────────────────
+
+    private loadRecentGateways(): RecentGateway[] {
+        try {
+            const raw = localStorage.getItem(RECENT_KEY)
+            if (raw) return JSON.parse(raw)
+        } catch {
+            // ignore
+        }
+        return []
+    }
+
+    private loadSuggested(): WalletPickerSuggestedEntry[] {
+        try {
+            const raw = localStorage.getItem(SUGGESTED_KEY)
+            if (raw) return JSON.parse(raw)
+        } catch {
+            // ignore
+        }
+        return []
+    }
+
+    private removeRecentGateway(rpcUrl: string): void {
+        this.recentGateways = this.loadRecentGateways().filter(
+            (r) => r.rpcUrl !== rpcUrl
+        )
+        if (this.recentGateways.length === 0) {
+            localStorage.removeItem(RECENT_KEY)
+        } else {
+            localStorage.setItem(
+                RECENT_KEY,
+                JSON.stringify(this.recentGateways)
+            )
+        }
+        this.render()
+    }
+
+    // ── Entry derivation (mirrors swk-wallet-picker) ───────
+
+    private getAllEntries(): {
+        entry: WalletPickerEntry
+        isRecent: boolean
+    }[] {
+        const knownUrls = new Set(
+            this.entries
+                .filter((e) => e.type === 'remote' && e.url)
+                .map((e) => e.url)
+        )
+
+        const recentEntries = this.recentGateways
+            .filter((r) => !knownUrls.has(r.rpcUrl))
+            .map((r) => ({
+                entry: {
+                    providerId: 'remote:' + r.rpcUrl,
+                    name: r.name,
+                    type: 'remote' as const,
+                    url: r.rpcUrl,
+                    reuseGlobalWalletPopup: true,
+                } satisfies WalletPickerEntry,
+                isRecent: true,
+            }))
+
+        return [
+            ...this.entries.map((entry) => ({ entry, isRecent: false })),
+            ...recentEntries,
+        ]
+    }
+
+    private getSuggestedEntries(): WalletPickerSuggestedEntry[] {
+        const detected = this.getAllEntries()
+        const notInstalled = this.suggested.filter(
+            (s) => !detected.some((d) => d.entry.providerId === s.providerId)
+        )
+        return notInstalled.sort((a, b) => {
+            const aSupported = a.installUrls.some(
+                (u) => u.platform === this.platform
+            )
+            const bSupported = b.installUrls.some(
+                (u) => u.platform === this.platform
+            )
+            if (aSupported && !bSupported) return -1
+            if (!aSupported && bSupported) return 1
+            return a.name.localeCompare(b.name)
+        })
+    }
+
+    // ── Selection ──────────────────────────────────────────
+
+    private select(result: WalletPickerResult, icon?: string): void {
+        this.selected = result
+        this.selectedIcon = icon ?? null
+        this.errorMessage = ''
+        this.state = 'connecting'
+        this.render()
+
+        const pending = this.pending
+        this.pending = null
+        pending?.resolve(result)
+    }
+
+    private cancel(): void {
+        const pending = this.pending
+        this.pending = null
+        this.destroy()
+        pending?.reject(new Error('User closed the wallet picker'))
+    }
+
+    /** Return to the wallet list from the connecting view and signal the SDK. */
+    private requestBack(): void {
+        this.selected = null
+        this.selectedIcon = null
+        this.wcUri = null
+        this.wcQrDataUrl = null
+        this.errorMessage = ''
+        this.state = 'list'
+        this.render()
+
+        if (this.backPending) {
+            const back = this.backPending
+            this.backPending = null
+            back.resolve()
+        } else {
+            // Back was clicked before the SDK started awaiting it; remember it.
+            this.backRequested = true
+        }
+    }
+
+    private isWalletConnect(): boolean {
+        return this.selected?.providerId === 'walletconnect'
+    }
+
+    // ── Rendering ──────────────────────────────────────────
+
+    private render(): void {
+        // Mount the backdrop and content shell once so their entry animations
+        // (fade-in / slide-up) don't replay on every state change. Subsequent
+        // renders only swap the inner content.
+        const firstMount = !this.backdrop
+        if (firstMount) {
+            this.backdrop = el('div', '', {
+                class: 'discovery-modal-backdrop',
+            })
+            this.backdrop.addEventListener('click', (e) => {
+                if (e.target === this.backdrop) this.cancel()
+            })
+
+            this.contentEl = el('div', '', {
+                class: 'discovery-modal-content',
+                role: 'dialog',
+                'aria-modal': 'true',
+            })
+            this.backdrop.appendChild(this.contentEl)
+            this.shadow.appendChild(this.backdrop)
+        }
+
+        const content = this.contentEl!
+        const inner = el('div', '', { class: 'discovery-modal-inner' })
+        inner.appendChild(this.renderHeader())
+        inner.appendChild(this.renderBody())
+
+        if (this.state === 'list') {
+            inner.appendChild(this.renderFooter())
+        }
+
+        if (firstMount) {
+            content.appendChild(inner)
+            return
+        }
+
+        // FLIP the height: measure the current size, swap the content, measure
+        // the new size, then transition between the two.
+        this.clearHeightAnimation()
+        const prevHeight = content.offsetHeight
+        content.replaceChildren(inner)
+        const nextHeight = content.offsetHeight
+
+        if (prevHeight === nextHeight) return
+
+        content.style.height = `${prevHeight}px`
+        // Force a reflow so the browser commits the start height before we
+        // transition to the target height.
+        void content.offsetHeight
+        content.style.transition = 'height 220ms cubic-bezier(0.4, 0, 0.2, 1)'
+        content.style.height = `${nextHeight}px`
+
+        this.onHeightTransitionEnd = (e: TransitionEvent) => {
+            if (e.propertyName !== 'height') return
+            this.clearHeightAnimation()
+        }
+        content.addEventListener('transitionend', this.onHeightTransitionEnd)
+    }
+
+    /** Reset any in-flight height transition back to auto sizing. */
+    private clearHeightAnimation(): void {
+        const content = this.contentEl
+        if (!content) return
+        if (this.onHeightTransitionEnd) {
+            content.removeEventListener(
+                'transitionend',
+                this.onHeightTransitionEnd
+            )
+            this.onHeightTransitionEnd = undefined
+        }
+        content.style.transition = ''
+        content.style.height = ''
+    }
+
+    private renderHeader(): HTMLElement {
+        const header = el('div', '', { class: 'discovery-modal-header' })
+
+        const showBack = this.state === 'gateway' || this.state === 'connecting'
+        if (showBack) {
+            const back = el('button', '', {
+                class: 'discovery-modal-back',
+                type: 'button',
+                'aria-label': 'Go back',
+            })
+            back.innerHTML =
+                '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M10 4L6 8l4 4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>'
+            back.addEventListener('click', () => {
+                if (this.state === 'connecting') {
+                    this.requestBack()
+                } else {
+                    this.state = 'list'
+                    this.render()
+                }
+            })
+            header.appendChild(back)
+        }
+
+        const heading = el('div', '', { class: 'discovery-modal-heading' })
+        const title =
+            this.state === 'connecting'
+                ? this.isWalletConnect()
+                    ? 'Scan with your phone'
+                    : 'Connecting...'
+                : this.state === 'gateway'
+                  ? 'Remote Wallet'
+                  : 'Connect Wallet'
+        heading.appendChild(el('h2', title))
+        header.appendChild(heading)
+
+        const close = el('button', '', {
+            class: 'discovery-modal-close',
+            type: 'button',
+            'aria-label': 'Close modal',
+        })
+        close.innerHTML =
+            '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M12 4L4 12M4 4l8 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>'
+        close.addEventListener('click', () => this.cancel())
+        header.appendChild(close)
+
+        return header
+    }
+
+    private renderBody(): HTMLElement {
+        const body = el('div', '', { class: 'discovery-modal-body' })
+        const view = el('div', '', { class: 'discovery-modal-view' })
+
+        if (this.state === 'connecting') {
+            view.appendChild(this.renderConnecting())
+        } else if (this.state === 'gateway') {
+            view.appendChild(this.renderGateway())
+        } else {
+            view.appendChild(this.renderList())
+        }
+
+        body.appendChild(view)
+        return body
+    }
+
+    private renderList(): HTMLElement {
+        const container = el('div', '', { class: 'wallet-picker-container' })
+
+        if (this.errorMessage) {
+            container.appendChild(
+                el('div', this.errorMessage, {
+                    class: 'discovery-modal-error',
+                    role: 'alert',
+                })
+            )
+        }
+
+        // Order the flat list: saved remote connections first, then installed
+        // extensions, then WalletConnect, then other remote wallets, then
+        // everything else (not-yet-installed wallets).
+        const detected = this.getAllEntries()
+        const isWc = (e: WalletPickerEntry) => e.providerId === 'walletconnect'
+
+        const recent = detected.filter((d) => d.isRecent)
+        const installed = detected.filter(
+            (d) => !d.isRecent && d.entry.type === 'browser' && !isWc(d.entry)
+        )
+        const walletConnect = detected.filter(
+            (d) => !d.isRecent && isWc(d.entry)
+        )
+        const remote = detected.filter(
+            (d) => !d.isRecent && d.entry.type === 'remote' && !isWc(d.entry)
+        )
+        const rest = detected.filter(
+            (d) =>
+                !recent.includes(d) &&
+                !installed.includes(d) &&
+                !walletConnect.includes(d) &&
+                !remote.includes(d)
+        )
+
+        for (const { entry, isRecent } of [
+            ...recent,
+            ...installed,
+            ...walletConnect,
+            ...remote,
+        ]) {
+            container.appendChild(this.renderWalletItem(entry, isRecent))
+        }
+
+        // Remote Wallet (custom URL) connector, grouped with remote wallets.
+        const gatewayItem = el('div', '', { class: 'wallet-picker-item' })
+        const gatewayBtn = el('button', '', {
+            class: 'wallet-picker-item-main',
+            type: 'button',
+        })
+        const gwIcon = el('span', '', { class: 'wallet-icon' })
+        gwIcon.appendChild(
+            el('img', '', { src: cantonLogo, alt: 'Remote Wallet' })
+        )
+        const gwInfo = el('div', '', { class: 'wallet-info' })
+        gwInfo.appendChild(el('h3', 'Remote Wallet'))
+        gatewayBtn.append(gwIcon, gwInfo)
+        gatewayBtn.addEventListener('click', () => {
+            this.state = 'gateway'
+            this.render()
+        })
+        gatewayItem.appendChild(gatewayBtn)
+        container.appendChild(gatewayItem)
+
+        // The rest: any leftover detected wallets, then not-yet-installed ones.
+        for (const { entry, isRecent } of rest) {
+            container.appendChild(this.renderWalletItem(entry, isRecent))
+        }
+        for (const entry of this.getSuggestedEntries()) {
+            container.appendChild(this.renderSuggestedItem(entry))
+        }
+
+        // Wrap the scrollable list so the bottom fade can be pinned to the
+        // viewport bottom (an absolute overlay in a non-scrolling wrapper)
+        // rather than scrolling with the content.
+        const scroll = el('div', '', { class: 'wallet-picker-scroll' })
+        scroll.appendChild(container)
+        const fadeTop = el('div', '', {
+            class: 'wallet-picker-fade wallet-picker-fade-top',
+        })
+        const fade = el('div', '', { class: 'wallet-picker-fade' })
+        scroll.append(fadeTop, fade)
+
+        // Show a fade at the top once scrolled down (content above) and at the
+        // bottom while there's more to scroll to; hide each at its edge.
+        const updateFade = () => {
+            const scrollable =
+                container.scrollHeight - container.clientHeight > 1
+            const atTop = container.scrollTop <= 1
+            const atBottom =
+                container.scrollTop + container.clientHeight >=
+                container.scrollHeight - 1
+            fadeTop.classList.toggle('is-hidden', !scrollable || atTop)
+            fade.classList.toggle('is-hidden', !scrollable || atBottom)
+        }
+        container.addEventListener('scroll', updateFade, { passive: true })
+        requestAnimationFrame(updateFade)
+
+        return scroll
+    }
+
+    private renderWalletItem(
+        entry: WalletPickerEntry,
+        isRecent: boolean
+    ): HTMLElement {
+        const item = el('div', '', { class: 'wallet-picker-item' })
+
+        const main = el('button', '', {
+            class: 'wallet-picker-item-main',
+            type: 'button',
+        })
+
+        const icon = el('span', '', { class: 'wallet-icon' })
+        if (entry.icon) {
+            icon.appendChild(
+                el('img', '', { src: entry.icon, alt: entry.name })
+            )
+        } else if (entry.type === 'remote') {
+            // Remote wallets (e.g. saved gateways) default to the Canton logo.
+            icon.appendChild(
+                el('img', '', { src: cantonLogo, alt: entry.name })
+            )
+        } else {
+            const fallback = el('span', entry.name.charAt(0).toUpperCase(), {
+                class: 'wallet-icon-fallback',
+            })
+            icon.appendChild(fallback)
+        }
+
+        const info = el('div', '', { class: 'wallet-info' })
+        info.appendChild(el('h3', entry.name))
+
+        main.append(icon, info)
+
+        if (entry.type === 'browser') {
+            main.appendChild(
+                el('span', 'Installed', { class: 'wallet-installed-badge' })
+            )
+        }
+
+        main.addEventListener('click', () =>
+            this.select(
+                {
+                    providerId: entry.providerId,
+                    name: entry.name,
+                    type: entry.type,
+                    url: entry.url,
+                    reuseGlobalWalletPopup: entry.reuseGlobalWalletPopup,
+                },
+                entry.icon
+            )
+        )
+        item.appendChild(main)
+
+        if (isRecent && entry.url) {
+            const remove = el('button', '', {
+                class: 'wallet-picker-remove',
+                type: 'button',
+                'aria-label': `Remove ${entry.name}`,
+                title: 'Remove',
+            })
+            remove.innerHTML =
+                '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M12 4L4 12M4 4l8 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>'
+            remove.addEventListener('click', (e) => {
+                e.stopPropagation()
+                this.removeRecentGateway(entry.url as string)
+            })
+            item.appendChild(remove)
+        }
+
+        return item
+    }
+
+    private renderSuggestedItem(
+        entry: WalletPickerSuggestedEntry
+    ): HTMLElement {
+        // Prefer an install link for the user's current browser, else the first.
+        const preferred =
+            entry.installUrls.find((u) => u.platform === this.platform) ??
+            entry.installUrls[0]
+
+        const item = el('div', '', {
+            class: 'wallet-picker-item wallet-suggested-item',
+        })
+
+        const main = el('button', '', {
+            class: 'wallet-picker-item-main',
+            type: 'button',
+        })
+
+        const icon = el('span', '', { class: 'wallet-icon' })
+        if (entry.icon) {
+            icon.appendChild(
+                el('img', '', { src: entry.icon, alt: entry.name })
+            )
+        } else {
+            icon.innerHTML = BROWSER_ICON
+        }
+
+        const info = el('div', '', { class: 'wallet-info' })
+        info.appendChild(el('h3', entry.name))
+
+        const badge = el(
+            'span',
+            preferred ? `Get for ${preferred.platform}` : 'Get',
+            { class: 'wallet-get-badge' }
+        )
+
+        main.append(icon, info, badge)
+
+        if (preferred?.url) {
+            main.addEventListener('click', () => {
+                window.open(preferred.url, '_blank', 'noopener')
+            })
+        }
+
+        item.appendChild(main)
+        return item
+    }
+
+    private renderGateway(): HTMLElement {
+        const container = el('div', '', { class: 'gateway-view' })
+        container.appendChild(
+            el('p', 'Enter the URL of your Remote Wallet.', {
+                class: 'gateway-help',
+            })
+        )
+
+        const input = el('input', '', {
+            class: 'custom-url-input',
+            type: 'url',
+            'aria-label': 'Remote Wallet URL',
+            placeholder: 'https://wallet.example.com',
+        }) as HTMLInputElement
+
+        const button = el('button', 'Connect', {
+            class: 'gateway-connect-button',
+            type: 'button',
+        }) as HTMLButtonElement
+        button.disabled = true
+
+        const parse = (value: string): URL | undefined => {
+            const trimmed = value.trim()
+            if (!trimmed) return undefined
+            try {
+                const normalized = /^https?:\/\//i.test(trimmed)
+                    ? trimmed
+                    : `https://${trimmed}`
+                return new URL(normalized)
+            } catch {
+                return undefined
+            }
+        }
+
+        const connect = () => {
+            const parsed = parse(input.value)
+            if (!parsed) return
+            const normalizedUrl = parsed.toString()
+            this.select({
+                providerId: `custom:remote:${encodeURIComponent(normalizedUrl)}`,
+                name: parsed.hostname || 'Custom URL',
+                type: 'remote',
+                url: normalizedUrl,
+                reuseGlobalWalletPopup: false,
+            })
+        }
+
+        input.addEventListener('input', () => {
+            button.disabled = !parse(input.value)
+        })
+        input.addEventListener('keydown', (e) => {
+            if ((e as KeyboardEvent).key === 'Enter' && parse(input.value)) {
+                e.preventDefault()
+                connect()
+            }
+        })
+        button.addEventListener('click', connect)
+
+        container.append(input, button)
+        queueMicrotask(() => input.focus())
+        return container
+    }
+
+    private renderConnecting(): HTMLElement {
+        const container = el('div', '', { class: 'walletconnect-view' })
+
+        if (this.isWalletConnect()) {
+            if (this.wcQrDataUrl) {
+                container.appendChild(
+                    el('img', '', {
+                        class: 'walletconnect-qr',
+                        src: this.wcQrDataUrl,
+                        alt: 'WalletConnect QR code',
+                    })
+                )
+            } else {
+                const placeholder = el('div', '', {
+                    class: 'walletconnect-qr walletconnect-qr-placeholder',
+                })
+                placeholder.appendChild(
+                    el('div', '', { class: 'walletconnect-spinner' })
+                )
+                container.appendChild(placeholder)
+            }
+
+            const divider = el('div', '', { class: 'walletconnect-divider' })
+            divider.appendChild(
+                el('span', 'Or', { class: 'walletconnect-divider-label' })
+            )
+            container.appendChild(divider)
+
+            const copyBtn = el(
+                'button',
+                this.copied ? 'Copied!' : 'Copy link',
+                {
+                    class: 'walletconnect-copy-button',
+                    type: 'button',
+                }
+            ) as HTMLButtonElement
+            copyBtn.disabled = !this.wcUri
+            copyBtn.addEventListener('click', async () => {
+                if (!this.wcUri) return
+                try {
+                    await navigator.clipboard.writeText(this.wcUri)
+                    this.copied = true
+                    this.render()
+                    setTimeout(() => {
+                        this.copied = false
+                        if (!this.destroyed && this.state === 'connecting') {
+                            this.render()
+                        }
+                    }, 2000)
+                } catch {
+                    // ignore clipboard failures
+                }
+            })
+            container.appendChild(copyBtn)
+            return container
+        }
+
+        const loading = el('div', '', { class: 'connecting-loading' })
+        const ring = el('div', '', { class: 'connecting-spinner-ring' })
+        const avatar = el('span', '', { class: 'connecting-avatar' })
+        if (this.selectedIcon) {
+            avatar.appendChild(
+                el('img', '', {
+                    src: this.selectedIcon,
+                    alt: this.selected?.name ?? 'wallet',
+                })
+            )
+        } else {
+            avatar.appendChild(
+                el(
+                    'span',
+                    (this.selected?.name ?? 'W').charAt(0).toUpperCase(),
+                    { class: 'connecting-avatar-fallback' }
+                )
+            )
+        }
+        ring.appendChild(avatar)
+        loading.appendChild(ring)
+        loading.appendChild(
+            el('h3', `Connecting to ${this.selected?.name ?? 'wallet'}`, {
+                class: 'walletconnect-title',
+            })
+        )
+        loading.appendChild(
+            el('p', 'Approve the connection in your wallet to continue.', {
+                class: 'walletconnect-help',
+            })
+        )
+        container.appendChild(loading)
+        return container
+    }
+
+    private renderFooter(): HTMLElement {
+        const footer = el('div', '', { class: 'discovery-modal-footer' })
+        const link = el('a', '', {
+            class: 'discovery-modal-no-wallet',
+            href: 'https://github.com/canton-foundation/wallets/blob/main/WALLET_DIRECTORY.md',
+            target: '_blank',
+            rel: 'noopener',
+        })
+        link.innerHTML =
+            '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true"><rect x="3" y="6" width="18" height="13" rx="2.5" stroke="currentColor" stroke-width="1.8"/><path d="M3 9.5h12a2 2 0 0 1 2 2v1a2 2 0 0 1-2 2H3" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/><circle cx="15" cy="13" r="1.1" fill="currentColor"/></svg>'
+        link.appendChild(
+            el('span', 'Need a wallet?', {
+                class: 'discovery-modal-no-wallet-label',
+            })
+        )
+        footer.appendChild(link)
+        return footer
+    }
+}
+
+let active: WalletPickerModalController | null = null
+
+/**
+ * Opens the in-page wallet picker modal and resolves with the user's first
+ * selection. Subsequent retries after a failed connection are obtained via
+ * {@link waitForWalletPickerModalRetrySelection}.
+ */
+export async function pickWalletModal(
+    entries: WalletPickerEntry[]
+): Promise<WalletPickerResult> {
+    active?.destroy()
+    active = new WalletPickerModalController(entries)
+    return active.awaitSelection()
+}
+
+/** Closes the modal after a successful connection. */
+export function notifyWalletPickerModalConnected(): void {
+    active?.setConnected()
+}
+
+/** Shows an error in the modal and returns the user to the wallet list. */
+export function notifyWalletPickerModalError(message: string): void {
+    active?.setError(message)
+}
+
+/** Resolves with the next selection after an error; rejects if the modal was closed. */
+export async function waitForWalletPickerModalRetrySelection(): Promise<WalletPickerResult> {
+    if (!active || !active.isActive()) {
+        throw new Error('Wallet picker is not open')
+    }
+    return active.awaitSelection()
+}
+
+/**
+ * Resolves when the user clicks "back" from the connecting view. The SDK races
+ * this against the in-flight connection so it can abort the attempt and re-await
+ * a selection. If no modal is active it never resolves (loses the race).
+ */
+export function waitForWalletPickerModalBack(): Promise<void> {
+    if (!active || !active.isActive()) {
+        return new Promise<void>(() => {})
+    }
+    return active.awaitBack()
+}
+
+/** Feeds a WalletConnect pairing URI (and optional QR data URL) into the connecting view. */
+export function setWalletPickerModalWalletConnectUri(
+    uri: string,
+    qrDataUrl?: string
+): void {
+    active?.setWalletConnectUri(uri, qrDataUrl)
+}
+
+/** Forces the modal color scheme, or `'auto'` to follow `prefers-color-scheme`. */
+export type WalletPickerModalTheme = 'light' | 'dark' | 'auto'
+
+let modalTheme: WalletPickerModalTheme = 'auto'
+
+/**
+ * Sets the color scheme used by the in-page modal picker. Applies immediately
+ * to an open modal and to any opened later. `'auto'` follows the OS setting.
+ */
+export function setWalletPickerModalTheme(theme: WalletPickerModalTheme): void {
+    modalTheme = theme
+    active?.applyTheme(theme)
+}

--- a/examples/ping/src/App.tsx
+++ b/examples/ping/src/App.tsx
@@ -58,6 +58,8 @@ function App() {
                             onClick={() => {
                                 setLoading(true)
                                 disconnect().then(() => {
+                                    setLedgerApiVersion(undefined)
+                                    status()
                                     setLoading(false)
                                 })
                             }}

--- a/examples/ping/src/hooks/useStatus.ts
+++ b/examples/ping/src/hooks/useStatus.ts
@@ -19,7 +19,9 @@ export function useStatus(): {
     async function status() {
         await sdk
             .status()
-            .then(setStatusEvent)
+            .then((s) =>
+                setStatusEvent(s.connection?.isConnected ? s : undefined)
+            )
             .catch(() => {
                 setStatusEvent(undefined)
             })
@@ -30,26 +32,15 @@ export function useStatus(): {
     }, [])
 
     useEffect(() => {
-        if (statusEvent?.connection?.isConnected) {
-            console.debug('[use-status] Adding status changed listener')
-            const onStatusChanged = (status: sdk.dappAPI.StatusEvent) => {
-                console.debug(
-                    '[use-status] Received status changed event:',
-                    status
-                )
-                setStatusEvent(
-                    status.connection?.isConnected ? status : undefined
-                )
-            }
-
-            sdk.onStatusChanged(onStatusChanged)
-
-            return () => {
-                console.debug('[use-status] Removing status changed listener')
-                sdk.removeOnStatusChanged(onStatusChanged)
-            }
+        const onStatusChanged = (s: sdk.dappAPI.StatusEvent) => {
+            setStatusEvent(s.connection?.isConnected ? s : undefined)
         }
-    }, [statusEvent])
+
+        sdk.onStatusChanged(onStatusChanged)
+        return () => {
+            sdk.removeOnStatusChanged(onStatusChanged)
+        }
+    }, [])
 
     return {
         status,

--- a/examples/ping/tests/walletpicker-modal.spec.ts
+++ b/examples/ping/tests/walletpicker-modal.spec.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    expect,
+    openWalletPicker,
+    test,
+    WALLET_PICKER_MODAL_HOST,
+    walletPickerModalHost,
+    walletPickerModalRowByTitle,
+} from '@canton-network/core-wallet-test-utils'
+import type { Page } from '@playwright/test'
+import {
+    connectPingDapp,
+    createPingDappWalletGateway,
+    DAPP_URL,
+    expectDappConnected,
+    expectDappDisconnected,
+    GATEWAY_NAME,
+} from './ping-test-helpers.js'
+
+test.describe('wallet picker modal (SDK default)', () => {
+    test('connect opens an in-page modal, not a picker popup', async ({
+        page: dappPage,
+    }: {
+        page: Page
+    }) => {
+        await dappPage.goto(DAPP_URL)
+        await expect(dappPage).toHaveTitle(/Example dApp/)
+        await expectDappDisconnected(dappPage)
+
+        const connectButton = dappPage.getByTestId('connect-wallet')
+        const picker = await openWalletPicker(dappPage, connectButton)
+
+        expect(picker.kind).toBe('modal')
+
+        const host = walletPickerModalHost(dappPage)
+        await expect(
+            host,
+            'SDK default should mount the in-page wallet picker modal'
+        ).toBeAttached()
+        await expect(
+            host.getByRole('heading', { name: 'Connect Wallet', level: 2 }),
+            'modal title should be Connect Wallet'
+        ).toBeVisible()
+        await expect(
+            walletPickerModalRowByTitle(dappPage, 'Remote Wallet'),
+            'modal list should include the Remote Wallet entry'
+        ).toBeVisible()
+        await expect(
+            host.getByRole('link', { name: /Need a wallet/i }),
+            'modal footer should offer Need a wallet?'
+        ).toBeVisible()
+
+        await host.getByLabel('Close modal').click()
+        await expect(host).toHaveCount(0)
+        await expectDappDisconnected(dappPage)
+    })
+
+    test('backdrop dismiss and Remote Wallet back stay on the dApp page', async ({
+        page: dappPage,
+    }: {
+        page: Page
+    }) => {
+        await dappPage.goto(DAPP_URL)
+        await expectDappDisconnected(dappPage)
+
+        const connectButton = dappPage.getByTestId('connect-wallet')
+        const picker = await openWalletPicker(dappPage, connectButton)
+        expect(picker.kind).toBe('modal')
+
+        const host = walletPickerModalHost(dappPage)
+        await walletPickerModalRowByTitle(dappPage, 'Remote Wallet').click()
+        await expect(
+            host.getByRole('heading', { name: 'Remote Wallet', level: 2 })
+        ).toBeVisible()
+        await expect(host.getByLabel('Remote Wallet URL')).toBeVisible()
+
+        await host.getByLabel('Go back').click()
+        await expect(
+            host.getByRole('heading', { name: 'Connect Wallet', level: 2 })
+        ).toBeVisible()
+        await expect(host).toBeAttached()
+        await expectDappDisconnected(dappPage)
+
+        // Click the backdrop node itself (handler requires target === backdrop).
+        await host.locator('.discovery-modal-backdrop').evaluate((el) => {
+            el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+        })
+        await expect(dappPage.locator(WALLET_PICKER_MODAL_HOST)).toHaveCount(0)
+        await expectDappDisconnected(dappPage)
+    })
+
+    test('connects through the modal to the live remote Wallet Gateway', async ({
+        page: dappPage,
+    }: {
+        page: Page
+    }) => {
+        const wg = createPingDappWalletGateway(dappPage)
+        await connectPingDapp(wg, dappPage)
+        await expectDappConnected(dappPage, GATEWAY_NAME)
+
+        await expect(
+            dappPage.locator(WALLET_PICKER_MODAL_HOST),
+            'modal should be gone after a successful connection'
+        ).toHaveCount(0)
+
+        await dappPage.getByTestId('disconnect-wallet').click()
+        await expectDappDisconnected(dappPage)
+    })
+})

--- a/examples/ping/tests/walletpicker.spec.ts
+++ b/examples/ping/tests/walletpicker.spec.ts
@@ -1,12 +1,22 @@
 // Copyright (c) 2025-2026 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { test, expect } from '@canton-network/core-wallet-test-utils'
-import { Page } from '@playwright/test'
+import {
+    expect,
+    openWalletPicker,
+    test,
+    WALLET_PICKER_MODAL_HOST,
+    walletPickerModalHost,
+    walletPickerModalRowByTitle,
+} from '@canton-network/core-wallet-test-utils'
+import type { Page } from '@playwright/test'
 import {
     connectPingDapp,
+    connectWalletGateway,
     createPingDappWalletGateway,
+    expectDappConnected,
     expectDappDisconnected,
+    GATEWAY_NAME,
 } from './ping-test-helpers.js'
 
 test('wallet picker: handling error cases', async ({
@@ -20,51 +30,46 @@ test('wallet picker: handling error cases', async ({
     // 1. Connect via custom wallet API URL and verify connected status.
     await connectPingDapp(wg, dappPage)
 
-    // 2. Logout from the popup and verify disconnected status.
-    await test.step('log out from the popup', async () => {
-        await wg.logoutFromPopup()
+    // Modal connect closes the WG login popup; use dApp disconnect instead of WG logout.
+    await test.step('disconnect from the dApp', async () => {
+        await dappPage.getByTestId('disconnect-wallet').click()
         await expectDappDisconnected(dappPage)
     })
 
-    // 3. Enter an invalid URL, recover via "Try Again", and connect injected.
-    const pickerPopup =
-        await test.step('reopen the wallet picker', async () => {
-            await expect(
-                connectButton,
-                'the dApp should be ready to connect again after logging out'
-            ).toBeEnabled()
+    const picker = await test.step('reopen the wallet picker', async () => {
+        await expect(
+            connectButton,
+            'the dApp should be ready to connect again after logging out'
+        ).toBeEnabled()
+        return openWalletPicker(dappPage, connectButton)
+    })
 
-            const discoverPopupPromise = dappPage.waitForEvent('popup')
-            await connectButton.click()
-            return discoverPopupPromise
-        })
+    expect(picker.kind, 'SDK default picker should be the in-page modal').toBe(
+        'modal'
+    )
 
-    await test.step('an unreachable wallet API URL surfaces a retryable error', async () => {
-        await pickerPopup
-            .getByRole('textbox', { name: 'Wallet API URL' })
-            .fill('thisisnotarealurl')
-        await pickerPopup
-            .getByRole('button', { name: 'Connect', exact: true })
-            .click()
+    const host = walletPickerModalHost(dappPage)
+
+    await test.step('an unreachable wallet API URL surfaces an error in the modal', async () => {
+        await walletPickerModalRowByTitle(dappPage, 'Remote Wallet').click()
+        await host.getByLabel('Remote Wallet URL').fill('thisisnotarealurl')
+        await host.locator('.gateway-connect-button').click()
 
         await expect(
-            pickerPopup.getByRole('button', { name: 'Try Again' }),
-            'failing to reach a wallet API should show retry button'
+            host.locator('.discovery-modal-error[role="alert"]'),
+            'failing to reach a wallet API should show an error alert in the modal'
+        ).toBeVisible({ timeout: 30_000 })
+        await expect(
+            host.getByRole('heading', { name: 'Connect Wallet', level: 2 }),
+            'error path should show the list heading together with the alert'
         ).toBeVisible()
     })
 
-    await test.step('Try Again returns to the picker without the failed entry', async () => {
-        await pickerPopup.getByRole('button', { name: 'Try Again' }).click()
+    await test.step('retry after error connects through the live gateway', async () => {
+        await host.getByLabel('Close modal').click()
+        await expect(dappPage.locator(WALLET_PICKER_MODAL_HOST)).toHaveCount(0)
 
-        await expect(
-            pickerPopup.getByRole('textbox', { name: 'Wallet API URL' }),
-            'Try Again should return to the wallet picker list'
-        ).toBeVisible()
-        await expect(
-            pickerPopup.getByRole('button', {
-                name: 'Connect to thisisnotarealurl',
-            }),
-            'the entry that failed to connect should not be offered again'
-        ).toHaveCount(0)
+        await connectWalletGateway(wg, dappPage)
+        await expectDappConnected(dappPage, GATEWAY_NAME)
     })
 })

--- a/sdk/dapp-sdk/src/adapter/walletconnect-adapter.test.ts
+++ b/sdk/dapp-sdk/src/adapter/walletconnect-adapter.test.ts
@@ -129,7 +129,10 @@ describe('WalletConnectAdapter', () => {
         expect(SignClientInit).toHaveBeenCalledWith(
             expect.objectContaining({ projectId: 'test-project-id' })
         )
-        expect(onUri).toHaveBeenCalledWith('wc:test-uri')
+        expect(onUri).toHaveBeenCalledWith(
+            'wc:test-uri',
+            expect.stringMatching(/^data:image\/png;base64,/)
+        )
         expect(statusListener).toHaveBeenCalledWith(
             expect.objectContaining({
                 connection: {

--- a/sdk/dapp-sdk/src/adapter/walletconnect-adapter.ts
+++ b/sdk/dapp-sdk/src/adapter/walletconnect-adapter.ts
@@ -106,7 +106,9 @@ export interface WalletConnectAdapterConfig {
     /** Whether to trigger a canton_signMessage request after the session is established. */
     signInWithCanton?: SIWXMessageParams
     /** Called with the pairing URI so the dApp can display or forward it. */
-    onUri?: (uri: string) => void
+    onUri?: (uri: string, qrDataUrl?: string) => void
+    /** When false, do not open the legacy popup for URI display. */
+    openPopupForUri?: boolean
     onSignInWithCanton?: (result: SignInWithCantonResult) => void
 }
 
@@ -129,14 +131,18 @@ export class WalletConnectAdapter
     private readonly chainId: string
     private readonly metadata:
         WalletConnectAdapterConfig['metadata'] | undefined
-    private readonly onUri: ((uri: string) => void) | undefined
+    private readonly onUri:
+        ((uri: string, qrDataUrl?: string) => void) | undefined
     private readonly onSignInWithCanton:
         ((result: SignInWithCantonResult) => void) | undefined
+    private readonly openPopupForUri: boolean
     private readonly signInWithCanton: WalletConnectAdapterConfig['signInWithCanton']
 
     private signClient: SignClient | null = null
     private session: SessionTypes.Struct | null = null
     private initPromise: Promise<SignClient> | null = null
+    private pendingApproval: (() => Promise<SessionTypes.Struct>) | null = null
+    private prepareUriPromise: Promise<void> | null = null
 
     // Event handling with buffering for events that arrive before listeners
     private listeners: { [event: string]: EventListener<unknown>[] } = {}
@@ -152,6 +158,7 @@ export class WalletConnectAdapter
         this.chainId = config.chainId ?? 'canton:devnet'
         this.metadata = config.metadata
         this.onUri = config.onUri
+        this.openPopupForUri = config.openPopupForUri ?? true
         this.onSignInWithCanton = config.onSignInWithCanton
     }
 
@@ -404,22 +411,59 @@ export class WalletConnectAdapter
         })
     }
 
-    private async establishSession(): Promise<void> {
-        const client = await this.initSignClient()
+    /**
+     * Eagerly create a WalletConnect pairing and emit the URI/QR before the
+     * user commits to connecting. The resulting approval is cached and consumed
+     * by the next {@link establishSession} call, so the QR can be shown without
+     * a loading state.
+     */
+    async prepareUri(): Promise<void> {
+        if (this.session || this.pendingApproval) return
+        if (this.prepareUriPromise) return this.prepareUriPromise
 
-        const { uri, approval } = await client.connect({
-            requiredNamespaces: {
-                canton: {
-                    chains: [this.chainId],
-                    methods: CANTON_WC_METHODS,
-                    events: CANTON_WC_EVENTS,
+        this.prepareUriPromise = (async () => {
+            const client = await this.initSignClient()
+
+            const { uri, approval } = await client.connect({
+                requiredNamespaces: {
+                    canton: {
+                        chains: [this.chainId],
+                        methods: CANTON_WC_METHODS,
+                        events: CANTON_WC_EVENTS,
+                    },
                 },
-            },
-        })
+            })
 
-        if (uri) {
-            this.onUri?.(uri)
-            await this.showUriInPopup(uri)
+            this.pendingApproval = approval
+
+            if (uri) {
+                const qrDataUrl = await this.generateQrDataUrl(uri)
+                if (this.openPopupForUri) {
+                    await this.showUriInPopup(uri, qrDataUrl)
+                }
+                this.onUri?.(uri, qrDataUrl)
+            }
+        })()
+
+        try {
+            await this.prepareUriPromise
+        } finally {
+            this.prepareUriPromise = null
+        }
+    }
+
+    private async establishSession(): Promise<void> {
+        // Reuse a pre-generated pairing/approval when available so the QR can
+        // be shown immediately without a loading state.
+        if (!this.pendingApproval) {
+            await this.prepareUri()
+        }
+
+        const approval = this.pendingApproval
+        this.pendingApproval = null
+
+        if (!approval) {
+            throw new Error('WalletConnect pairing could not be established')
         }
 
         this.session = await approval()
@@ -471,22 +515,27 @@ export class WalletConnectAdapter
         }
     }
 
-    private async showUriInPopup(uri: string): Promise<void> {
+    private async generateQrDataUrl(uri: string): Promise<string | undefined> {
+        try {
+            const QRCode = await import('qrcode')
+            return await QRCode.toDataURL(uri, {
+                width: 200,
+                margin: 2,
+                color: { dark: '#000000', light: '#ffffff' },
+            })
+        } catch {
+            // qrcode package not installed — skip QR generation
+            return undefined
+        }
+    }
+
+    private async showUriInPopup(
+        uri: string,
+        qrDataUrl?: string
+    ): Promise<void> {
         try {
             const popupWin = window.open('', 'wallet-popup')
             if (!popupWin || popupWin.closed) return
-
-            let qrDataUrl: string | undefined
-            try {
-                const QRCode = await import('qrcode')
-                qrDataUrl = await QRCode.toDataURL(uri, {
-                    width: 200,
-                    margin: 2,
-                    color: { dark: '#000000', light: '#ffffff' },
-                })
-            } catch {
-                // qrcode package not installed — skip QR generation
-            }
 
             const targetOrigin =
                 typeof window !== 'undefined' ? window.location.origin : '*'

--- a/sdk/dapp-sdk/src/index.ts
+++ b/sdk/dapp-sdk/src/index.ts
@@ -7,6 +7,14 @@ import '@canton-network/core-provider-dapp'
 // ── Asset exports (icons for wallet adapters) ──
 export { CANTON_LOGO_PNG, WALLET_GATEWAY_ICON } from './assets'
 
+// ── Default wallet picker (in-page modal) ──
+export {
+    pickWallet,
+    setWalletPickerModalTheme,
+    setWalletPickerModalWalletConnectUri,
+} from '@canton-network/core-wallet-ui-components'
+export type { WalletPickerModalTheme } from '@canton-network/core-wallet-ui-components'
+
 // ── Client API (primary) ──
 export { DappClient } from './client'
 export type { DappClientOptions } from './client'
@@ -49,6 +57,7 @@ export {
     DappSDK,
     sdk as dappSDK,
     init,
+    setWalletPicker,
     connect,
     disconnect,
     isConnected,

--- a/sdk/dapp-sdk/src/sdk.test.ts
+++ b/sdk/dapp-sdk/src/sdk.test.ts
@@ -62,6 +62,7 @@ const {
     mockNotifyWalletPickerConnected,
     mockNotifyWalletPickerError,
     mockWaitForWalletPickerRetrySelection,
+    mockWaitForWalletPickerModalBack,
     mockClearAllLocalState,
     remoteAdapterInstances,
     RemoteAdapterMock,
@@ -132,6 +133,9 @@ const {
         mockNotifyWalletPickerConnected: vi.fn(),
         mockNotifyWalletPickerError: vi.fn(),
         mockWaitForWalletPickerRetrySelection: vi.fn(),
+        mockWaitForWalletPickerModalBack: vi.fn(
+            () => new Promise<void>(() => {})
+        ),
         mockClearAllLocalState: vi.fn(),
         remoteAdapterInstances,
         RemoteAdapterMock,
@@ -158,10 +162,11 @@ vi.mock('@canton-network/core-wallet-ui-components', async (importOriginal) => {
         >()
     return {
         ...actual,
-        notifyWalletPickerConnected: mockNotifyWalletPickerConnected,
-        notifyWalletPickerError: mockNotifyWalletPickerError,
-        waitForWalletPickerRetrySelection:
+        notifyWalletPickerModalConnected: mockNotifyWalletPickerConnected,
+        notifyWalletPickerModalError: mockNotifyWalletPickerError,
+        waitForWalletPickerModalRetrySelection:
             mockWaitForWalletPickerRetrySelection,
+        waitForWalletPickerModalBack: mockWaitForWalletPickerModalBack,
     }
 })
 
@@ -426,7 +431,7 @@ describe('DappSDK', () => {
             await expect(sdk.connect()).resolves.toEqual(connectedResult())
 
             expect(mockClearAllLocalState).toHaveBeenCalled()
-            expect(mockNotifyWalletPickerConnected).toHaveBeenCalledWith(false)
+            expect(mockNotifyWalletPickerConnected).toHaveBeenCalled()
             expect(storage.getKernelDiscovery()).toEqual({
                 walletType: 'remote',
                 url: 'https://gateway.test',

--- a/sdk/dapp-sdk/src/sdk.ts
+++ b/sdk/dapp-sdk/src/sdk.ts
@@ -19,7 +19,12 @@ import {
 import {
     notifyWalletPickerConnected,
     notifyWalletPickerError,
+    notifyWalletPickerModalConnected,
+    notifyWalletPickerModalError,
     pickWallet,
+    pickWalletModal,
+    waitForWalletPickerModalBack,
+    waitForWalletPickerModalRetrySelection,
     waitForWalletPickerRetrySelection,
 } from '@canton-network/core-wallet-ui-components'
 import type {
@@ -81,7 +86,8 @@ function normalizeConnectOptions(
 
 export class DappSDK {
     private readonly RECENT_GATEWAYS_KEY = 'splice_wallet_picker_recent'
-    private readonly walletPicker: WalletPickerFn
+    private walletPicker: WalletPickerFn
+    private pickerKind: 'modal' | 'popup' = 'modal'
     private discovery: DiscoveryClient | null = null
     private client: DappClient | null = null
     private initPromise: Promise<unknown> | null = null
@@ -90,7 +96,47 @@ export class DappSDK {
 
     constructor(options?: { walletPicker?: WalletPickerFn | undefined }) {
         this.walletPicker =
-            options?.walletPicker ?? (pickWallet as WalletPickerFn)
+            options?.walletPicker ?? (pickWalletModal as WalletPickerFn)
+        this.pickerKind = this.resolvePickerKind(this.walletPicker)
+    }
+
+    /**
+     * Override the wallet picker used when connecting. Must be called before
+     * {@link DappSDK.init}/{@link DappSDK.connect} so the picker is captured by
+     * the underlying DiscoveryClient. Passing `undefined` restores the default
+     * modal picker.
+     */
+    setWalletPicker(picker: WalletPickerFn | undefined): void {
+        this.walletPicker = picker ?? (pickWalletModal as WalletPickerFn)
+        this.pickerKind = this.resolvePickerKind(this.walletPicker)
+    }
+
+    /** The bundled popup picker drives a separate window; everything else
+     * (default modal, custom) is treated as the in-page modal flow. */
+    private resolvePickerKind(picker: WalletPickerFn): 'modal' | 'popup' {
+        return (picker as unknown) === pickWallet ? 'popup' : 'modal'
+    }
+
+    private notifyPickerConnected(reuseGlobalWalletPopup?: boolean): void {
+        if (this.pickerKind === 'popup') {
+            notifyWalletPickerConnected(reuseGlobalWalletPopup)
+        } else {
+            notifyWalletPickerModalConnected()
+        }
+    }
+
+    private notifyPickerError(message: string): void {
+        if (this.pickerKind === 'popup') {
+            notifyWalletPickerError(message)
+        } else {
+            notifyWalletPickerModalError(message)
+        }
+    }
+
+    private waitForPickerRetry() {
+        return this.pickerKind === 'popup'
+            ? waitForWalletPickerRetrySelection()
+            : waitForWalletPickerModalRetrySelection()
     }
 
     private async registerAdapters(
@@ -408,7 +454,42 @@ export class DappSDK {
                 try {
                     // creates provider based on the adapter
                     // provider stores (and reads from storage) the session token and the access token
-                    await discovery.connect(targetId)
+                    // Race the connection against a "back" click in the picker
+                    // so the user can abort a slow attempt and pick again.
+                    const connectPromise = discovery.connect(targetId)
+                    connectPromise.catch(() => {
+                        // Swallow late rejections if the user already went back.
+                    })
+                    const outcome = await Promise.race([
+                        connectPromise.then(() => 'connected' as const),
+                        waitForWalletPickerModalBack().then(
+                            () => 'back' as const
+                        ),
+                    ])
+
+                    if (outcome === 'back') {
+                        // Abort the in-flight attempt and re-await a selection.
+                        try {
+                            await discovery.disconnect()
+                        } catch {
+                            // best-effort teardown of any partial session
+                        }
+                        this.client = null
+
+                        try {
+                            const retrySelection =
+                                await this.waitForPickerRetry()
+                            connectionAttempts.dispatchEvent(
+                                new CustomEvent<WalletPickerEntry>('attempt', {
+                                    detail: retrySelection,
+                                })
+                            )
+                        } catch (retryError) {
+                            cleanup()
+                            reject(retryError)
+                        }
+                        return
+                    }
 
                     const session = discovery.getActiveSession()
                     if (!session) {
@@ -443,18 +524,17 @@ export class DappSDK {
                         }
                     }
 
-                    notifyWalletPickerConnected(info.reuseGlobalWalletPopup)
+                    this.notifyPickerConnected(info.reuseGlobalWalletPopup)
                     cleanup()
                     resolve(s.connection)
                 } catch (error) {
                     const message = this.formatConnectionErrorMessage(error)
-                    notifyWalletPickerError(message)
+                    this.notifyPickerError(message)
 
                     this.client = null
 
                     try {
-                        const retrySelection =
-                            await waitForWalletPickerRetrySelection()
+                        const retrySelection = await this.waitForPickerRetry()
                         connectionAttempts.dispatchEvent(
                             new CustomEvent<WalletPickerEntry>('attempt', {
                                 detail: retrySelection,
@@ -618,6 +698,9 @@ export function connect(
 
 export const init = (options?: DappSDKConnectOptions): Promise<void> =>
     sdk.init(options)
+
+export const setWalletPicker = (picker: WalletPickerFn | undefined): void =>
+    sdk.setWalletPicker(picker)
 
 export const disconnect = (): Promise<null> => sdk.disconnect()
 

--- a/wallet-gateway/extension/tests/e2e/pages/ping-page.ts
+++ b/wallet-gateway/extension/tests/e2e/pages/ping-page.ts
@@ -23,13 +23,27 @@ export class PingPage {
             this.page,
             this.page.getByTestId('connect-wallet')
         )
-        const wallet = picker.getByRole('button', {
-            name: 'Connect to Canton Wallet',
-        })
+        const wallet = picker.page
+            .locator('.wallet-picker-item-main, .wallet-card')
+            .filter({ hasText: /Canton Wallet/i })
+            .first()
         await expect(wallet).toBeVisible()
-        await expect(picker.getByLabel('Install Canton Wallet')).toHaveCount(0)
+        if (picker.kind === 'modal') {
+            await expect(
+                wallet.locator('.wallet-installed-badge')
+            ).toBeVisible()
+        } else {
+            await expect(
+                picker.page.getByLabel('Install Canton Wallet')
+            ).toHaveCount(0)
+        }
 
-        const pickerClosed = picker.waitForEvent('close')
+        const pickerClosed =
+            picker.kind === 'popup'
+                ? picker.page.waitForEvent('close')
+                : picker.dappPage
+                      .locator('[data-swk-wallet-picker-modal]')
+                      .waitFor({ state: 'detached' })
         await wallet.click()
         await pickerClosed
 

--- a/wallet-gateway/remote/src/config/Config.test.ts
+++ b/wallet-gateway/remote/src/config/Config.test.ts
@@ -8,7 +8,7 @@ test('config from json file', async () => {
     const resp = ConfigUtils.loadConfigFile('../test/config.json')
     expect(resp.bootstrap.networks[0].name).toBe('Local (OAuth IDP)')
     expect(resp.bootstrap.networks[0].ledgerApi.baseUrl).toBe(
-        'http://127.0.0.1:5003'
+        'http://127.0.0.1:2975'
     )
     expect(resp.bootstrap.networks[0].auth.clientId).toBe('operator')
     expect(resp.bootstrap.networks[0].auth.scope).toBe(

--- a/wallet-gateway/test/config.json
+++ b/wallet-gateway/test/config.json
@@ -76,7 +76,7 @@
                     "clientSecret": "service-account-secret"
                 },
                 "ledgerApi": {
-                    "baseUrl": "http://127.0.0.1:5003"
+                    "baseUrl": "http://127.0.0.1:2975"
                 }
             },
             {
@@ -99,7 +99,7 @@
                     "clientSecret": "admin-client-secret"
                 },
                 "ledgerApi": {
-                    "baseUrl": "http://127.0.0.1:5003"
+                    "baseUrl": "http://127.0.0.1:2975"
                 }
             },
             {
@@ -123,7 +123,7 @@
                     "clientSecret": "admin-client-secret"
                 },
                 "ledgerApi": {
-                    "baseUrl": "http://127.0.0.1:5003"
+                    "baseUrl": "http://127.0.0.1:2975"
                 }
             },
             {
@@ -149,7 +149,7 @@
                     "clientSecret": "admin-client-secret"
                 },
                 "ledgerApi": {
-                    "baseUrl": "http://127.0.0.1:5003"
+                    "baseUrl": "http://127.0.0.1:2975"
                 }
             },
             {


### PR DESCRIPTION
## Why

dApps should open the wallet picker as an in-page modal by default. Popup stays available with `setWalletPicker(pickWallet)`. Continues #2237.

## What we did

Took the modal from draft shape into something we could ship as the SDK default, then rewired everything that assumed popup.

- Built the production modal UI (~940 lines) plus styles, and Chromium unit tests (~735 lines) covering open, select, dismiss, error, and retry
- Refactored dapp-sdk picker plumbing: default is `pickWalletModal`; popup is opt-in; connected/error/retry/back split by modal vs popup; WalletConnect QR mounts in the modal
- Reworked Playwright helpers (`openWalletPicker`, modal host/row locators, WG connect) so e2e drives the new path instead of waiting on a picker popup
- Wrote `walletpicker-modal.spec.ts` for open / backdrop+back / live remote connect
- Rewrote `walletpicker.spec.ts` for modal error UX (in-modal alert, not popup "Try Again"). Hit a real lifecycle bug: after modal connect the WG login window closes, so WG popup logout no longer clears dApp Status. Switched that step to dApp Disconnect and fixed ping `App` / `useStatus` so Status clears on disconnect
- Aligned extension `ping-page.ts` with the modal default

## Ledger port (`2975`)

Localnet exposes JSON Ledger API on `2975`, not `5003`. Updated `wallet-gateway/test/config.json` and `Config.test.ts` so bootstrap/connect e2e hits the real localnet port (same as `example-config`).

## Testing (what we actually ran)

- Clean / build / unit on touched packages (`core-wallet-ui-components`, `dapp-sdk`, `core-wallet-test-utils`, `wallet-gateway-remote`)
- Full monorepo: `pnpm clean:all` → `build:all --skip-nx-cache` → `test:all`
- E2e against live localnet + `start:all`. First connect runs failed after remote `clean` wiped sqlite (empty `networks`). Reseeded DB, confirmed 6 networks, re-ran until green:

```bash
CI=1 pnpm nx playwright:e2e @canton-network/example-ping -- \
  tests/walletpicker-modal.spec.ts tests/walletpicker.spec.ts --project=chromium
```

Result: 4/4 passed.

## Test plan

- [x] Touched-package units + `test:all`
- [x] Modal + picker e2e (chromium), 4/4
- [ ] Optional: full ping chromium e2e
- [ ] Manual: default modal; `setWalletPicker(pickWallet)` restores popup