### PR TITLE
test: mock postMessage in popup unit tests

### DIFF
--- a/core/wallet-ui-components/src/windows/popup.test.ts
+++ b/core/wallet-ui-components/src/windows/popup.test.ts
@@ -12,6 +12,7 @@ function createMockPopupWindow() {
         close: vi.fn(() => {
             win.closed = true
         }),
+        postMessage: vi.fn(),
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
     }


### PR DESCRIPTION
## Why

`popup.open(url)` polls with `win.postMessage` every 500ms. The popup unit-test mock never defined `postMessage`, so Vitest can exit red with unhandled `TypeError: win.postMessage is not a function` even when all assertions pass (flake, worse under serial / slow runs).

## Change

One line in `popup.test.ts`: add `postMessage: vi.fn()` to `createMockPopupWindow()`.

## Test

```bash
pnpm nx test @canton-network/core-wallet-ui-components --skip-nx-cache
```