### PR TITLE
fix: correct amount in transaction visualiser

### DIFF
--- a/core/tx-visualizer/src/index.ts
+++ b/core/tx-visualizer/src/index.ts
@@ -227,8 +227,18 @@ function extractChoiceIdAndAmount(obj: any) {
     const create = getNodeType(createNode)?.create
 
     const choiceId = exercise?.choiceId
-    const amount =
+    const exerciseAmount =
         getNumericValue(getFieldValue(exercise?.chosenValue, 'amount')) ??
+        getNumericValue(
+            getFieldValue(
+                getFieldValue(
+                    getFieldValue(exercise?.chosenValue, 'allocation'),
+                    'transferLeg'
+                ),
+                'amount'
+            )
+        )
+    const createAmount =
         getNumericValue(getFieldValue(create?.argument, 'amount')) ??
         getNumericValue(
             getFieldValue(
@@ -236,6 +246,7 @@ function extractChoiceIdAndAmount(obj: any) {
                 'initialAmount'
             )
         )
+    const amount = exercise ? exerciseAmount : createAmount
 
     return {
         ...(choiceId ? { choiceId } : {}),

--- a/core/wallet-test-utils/src/wallet-gateway.ts
+++ b/core/wallet-test-utils/src/wallet-gateway.ts
@@ -368,7 +368,11 @@ export class WalletGateway {
 
     async approveTransaction(
         start: () => Promise<void>,
-        opts?: { waitForClose?: boolean; isExternalSigning?: boolean }
+        opts?: {
+            waitForClose?: boolean
+            isExternalSigning?: boolean
+            review?: (approvalPage: Page) => Promise<void>
+        }
     ): Promise<{
         commandId: string
     }> {
@@ -396,6 +400,7 @@ export class WalletGateway {
             if (!commandId)
                 throw new Error('Approve popup has no commandId in URL')
 
+            await opts?.review?.(popupPage)
             await approveButton.click()
 
             if (opts?.isExternalSigning) {

--- a/examples/portfolio/tests/allocation.spec.ts
+++ b/examples/portfolio/tests/allocation.spec.ts
@@ -245,7 +245,15 @@ test.describe('OTC allocations', () => {
             name: 'Allocate',
         })
         await expect(allocateButton).toHaveClass(/MuiButton-sizeSmall/)
-        await wg.approveTransaction(() => allocateButton.click())
+        await wg.approveTransaction(() => allocateButton.click(), {
+            review: async (approvalPage) => {
+                const amountRow = approvalPage
+                    .getByRole('heading', { name: 'Amount' })
+                    .locator('..')
+
+                await expect(amountRow).toContainText('100.0000000000')
+            },
+        })
         await expect(
             aliceToBobLeg.getByRole('button', { name: 'Withdraw' })
         ).toBeVisible({ timeout: 15_000 })


### PR DESCRIPTION
Fixes #2409

`AllocationFactory_Allocate` stores its amount under `allocation.transferLeg.amount`. The visualizer now reads that value. Wrote a failing test to reproduce the error first buefore the fix