### PR TITLE
fix(wallet-gateway-remote): register parties/edit as a Vite build entry

### DIFF
--- a/wallet-gateway/remote/vite.config.ts
+++ b/wallet-gateway/remote/vite.config.ts
@@ -37,6 +37,10 @@ export default defineConfig({
                     __dirname,
                     'src/web/frontend/parties/add/index.html'
                 ),
+                editParty: resolve(
+                    __dirname,
+                    'src/web/frontend/parties/edit/index.html'
+                ),
                 settings: resolve(
                     __dirname,
                     'src/web/frontend/settings/index.html'


### PR DESCRIPTION
## Summary

- The `parties/edit` page (introduced in #2333, commit b04a5f8a) isn't listed in `rollupOptions.input`, so its `index.html` isn't emitted to `dist`.
- Dev mode is unaffected because Vite serves directly from `src`, but in built deployments `/parties/edit/` has no HTML to serve, so the party Edit button lands on a page the SPA can't handle.
- Adds the entry alongside `parties/add`.

cc @mateuszpiatkowski-da @pawelstepien-da — flagging since this follows on from #2333.

## Test plan

- [x] `vite build` on main: `dist/web/frontend/parties/edit/index.html` is absent.
- [x] `vite build` with this change: `dist/web/frontend/parties/edit/index.html` is emitted.
- [x] `vite` dev server serves `GET /parties/edit/` → 200 with `Wallet Gateway - Edit Party` HTML (which is why the bug was invisible locally).