### PR TITLE
chore: update recommended VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,8 @@
 {
     "recommendations": [
-        "arcanis.vscode-zipfs",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
-        "runem.lit-plugin"
+        "runem.lit-plugin",
+        "vitest.explorer"
     ]
 }


### PR DESCRIPTION
From what I understand the ZIP extension was used for yarn and is no loner needed. Instead I added the vitest extension for running tests from VS Code.
